### PR TITLE
Minimal stashcache

### DIFF
--- a/stash-cache/Authfile
+++ b/stash-cache/Authfile
@@ -1,0 +1,7 @@
+# Authfile for unauthenticated StashCache access
+################################################
+
+# All users are denied  read/lookup for path /user/ligo
+# All users are granted read/lookup for path /
+u * /user/ligo -rl \
+    /           rl

--- a/stash-cache/Dockerfile
+++ b/stash-cache/Dockerfile
@@ -10,3 +10,9 @@ ADD cron.d/* /etc/cron.d/
 ADD supervisord.d/* /etc/supervisord.d/
 ADD stash-cache-init.sh /usr/local/sbin/
 
+# Add a placeholder authfile, incase this cache isn't registered
+# and can't pull down a new one
+ADD Authfile /run/stash-cache/Authfile
+
+EXPOSE 8000
+

--- a/stash-cache/README.md
+++ b/stash-cache/README.md
@@ -10,18 +10,49 @@ users.
 A set of caches are operated across the OSG for the benefit of nearby sites;
 in addition, each site may run its own cache in order to reduce the amount of data transferred over the WAN.
 
-This document describes how to configure, start, and verify a Stash Cache container.
+This document describes how to configure, start, and verify a **Minimal** Stash Cache container.  There are no requirements to start a **Minimal** Stash Cache container.  Please follow [these instructions](https://opensciencegrid.org/docs/data/stashcache/install-cache/) to create a production Stash Cache server.
 
-Configuration
--------------
+Running a Container
+-------------------
+
+To run the container, use `docker run` with the following options, replacing the text within angle brackets with your
+own values:
+
+
+```
+$ docker run --rm --publish <HOST PORT>:8000 \
+             opensciencegrid/stash-cache:development
+```
+
+The `HOST PORT` is the port on your computer which will accept caching requests.  You may see some failures.  
+
+
+You can verify that it worked with the command:
+
+```
+$ curl http://localhost:8212/user/dweitzel/public/blast/queries/query1
+```
+
+Which should output:
+
+```
+>Derek's first query!
+MPVSDSGFDNSSKTMKDDTIPTEDYEEITKESEMGDATKITSKIDANVIEKKDTDSENNITIAQDDEKVSWLQRVVEFFE
+```
+
+Optional Configuration
+----------------------
 
 Before starting the container, write the following configuration on your docker host:
 
 1. Write a file containing the following required environment variables and values for your XCache:
 
-    - `XC_ROOTDIR`: The directory containing files to export from the cache
-    - `XC_SITENAME`: The server name used for monitoring and reporting
-    - `XC_PORT`: TCP port that XCache listens on
+    ```
+    # The directory containing files to export from the cache
+    XC_ROOTDIR=<dir>
+    # The server name used for monitoring and reporting
+    XC_SITENAME
+    ```
 
 ### Disabling OSG monitoring (optional) ###
 
@@ -33,18 +64,3 @@ the following in your environment variable configuration:
 DISABLE_OSG_MONITORING = true
 ```
 
-Running a Container
--------------------
-
-To run the container, use `docker run` with the following options, replacing the text within angle brackets with your
-own values:
-
-
-```
-$ docker run --env-file=<PATH TO ENV FILE> \
-             --volume <PATH TO HOST CERT>:/etc/grid-security/hostcert.pem \
-             --volume <PATH TO HOST KEY>:/etc/grid-security/hostkey.pem \
-             --publish <HOST PORT>:<XC_PORT> \
-             --hostname <XCACHE HOSTNAME> \
-             opensciencegrid/stash-cache:development
-```

--- a/xcache/xrootd/10-docker-env-var.cfg
+++ b/xcache/xrootd/10-docker-env-var.cfg
@@ -1,2 +1,11 @@
+if defined ?~XC_ROOTDIR
 set rootdir=$XC_ROOTDIR
+else
+set rootdir=/tmp
+fi
+
+if defined ?~XC_SITENAME
 set sitename=$XC_SITENAME
+else
+set sitename=Test_Docker_Site
+fi


### PR DESCRIPTION
This is all the changes for a **MINIMAL** working stashcache from Docker.  I assume the production one will be documented on the official docs website?

The **MINIMAL** StashCache **can**:
- Cache files directly into the docker image.
- Caches all public files in the federation.
- Report usage to GRACC

The **MINIMAL** StashCache **cannot**:
- Pull a new Authfile from topology since it isn't registered.
- Cache or download any authenticated data.
- Report cache status to the collector.opensciencegrid.org