### PR TITLE
Set /origin as the default for origin data (SOFTWARE-4138)

### DIFF
--- a/stash-origin/Dockerfile
+++ b/stash-origin/Dockerfile
@@ -1,5 +1,7 @@
 FROM opensciencegrid/xcache:fresh
 
+LABEL maintainer OSG Software <help@opensciencegrid.org>
+
 RUN yum -y install stash-origin --enablerepo=osg-minefield && \
     yum clean all --enablerepo=* && rm -rf /var/cache/yum/
 

--- a/stash-origin/Dockerfile
+++ b/stash-origin/Dockerfile
@@ -12,3 +12,5 @@ ADD supervisord.d/* /etc/supervisord.d/
 
 ADD xrootd/* /etc/xrootd/config.d/
 
+RUN mkdir /origin
+RUN chown xrootd:xrootd /origin

--- a/stash-origin/Dockerfile
+++ b/stash-origin/Dockerfile
@@ -2,6 +2,9 @@ FROM opensciencegrid/xcache:fresh
 
 LABEL maintainer OSG Software <help@opensciencegrid.org>
 
+# Default root dir
+ENV XC_ROOTDIR /origin
+
 RUN yum -y install stash-origin --enablerepo=osg-minefield && \
     yum clean all --enablerepo=* && rm -rf /var/cache/yum/
 

--- a/stash-origin/xrootd/10-origin-docker-env-var.cfg
+++ b/stash-origin/xrootd/10-origin-docker-env-var.cfg
@@ -1,3 +1,11 @@
-# Required setting for origin
-# Set it via docker env variable
-set originexport=$XC_ORIGINEXPORT
+# Allow users to specify their originexport relative to rootdir.
+# If XC_ORIGINEXPORT is not specified, the Stash Origin will expect to
+# serve its data out of /origin, i.e. users should mount the host
+# partition containing the origin data to /origin
+set rootdir=/
+
+if defined ?~XC_ORIGINEXPORT
+   set originexport=$XC_ORIGINEXPORT
+else
+   set originexport=/origin
+fi

--- a/stash-origin/xrootd/10-origin-docker-env-var.cfg
+++ b/stash-origin/xrootd/10-origin-docker-env-var.cfg
@@ -2,10 +2,8 @@
 # If XC_ORIGINEXPORT is not specified, the Stash Origin will expect to
 # serve its data out of /origin, i.e. users should mount the host
 # partition containing the origin data to /origin
-set rootdir=/
-
 if defined ?~XC_ORIGINEXPORT
-   set originexport=$XC_ORIGINEXPORT
+set originexport=$XC_ORIGINEXPORT
 else
-   set originexport=/origin
+set originexport=/
 fi

--- a/travis/stashcache-cache-config/Authfile
+++ b/travis/stashcache-cache-config/Authfile
@@ -1,3 +1,3 @@
 u * /user/ligo -rl \
-    /stashcache-travis-ci-test rl \
+    / rl \
     /user rl 

--- a/travis/stashcache-origin-config/10-origin-authfile.cfg
+++ b/travis/stashcache-origin-config/10-origin-authfile.cfg
@@ -1,4 +1,2 @@
 # Manually force the authentication to be public
 set StashOriginPublicAuthfile = /etc/xrootd/public-origin-authfile
-#set originexport = /stashcache-travis-ci-test
-all.export /stashcache-travis-ci-test

--- a/travis/stashcache-origin-config/authfile
+++ b/travis/stashcache-origin-config/authfile
@@ -1,1 +1,1 @@
-u * /stashcache-travis-ci-test rl
+u * / rl

--- a/travis/stashcache-origin-config/origin-env
+++ b/travis/stashcache-origin-config/origin-env
@@ -1,1 +1,0 @@
-XC_ORIGINEXPORT=/tmp

--- a/travis/test_stashcache.sh
+++ b/travis/test_stashcache.sh
@@ -10,9 +10,9 @@ docker run --rm \
        --name test_cache opensciencegrid/stash-cache:fresh &
 docker ps 
 sleep 25
-curl -v -sL http://localhost:8000/stashcache-travis-ci-test/test_file
+curl -v -sL http://localhost:8000/test_file
 
-online_md5="$(curl -sL http://localhost:8000/stashcache-travis-ci-test/test_file | md5sum | cut -d ' ' -f 1)"
+online_md5="$(curl -sL http://localhost:8000/test_file | md5sum | cut -d ' ' -f 1)"
 local_md5="$(md5sum $(pwd)/travis/stashcache-origin-config/test_file | cut -d ' ' -f 1)"
 if [ "$online_md5" != "$local_md5" ]; then
     echo "MD5sums do not match on stashcache"

--- a/travis/test_stashcache_origin.sh
+++ b/travis/test_stashcache_origin.sh
@@ -4,16 +4,15 @@
 
 docker run --rm \
        --network="host" \
-       --env-file=$(pwd)/travis/stashcache-origin-config/origin-env \
        --volume $(pwd)/travis/stashcache-origin-config/empty_stash-origin-auth.conf:/etc/supervisord.d/stash-origin-auth.conf \
        --volume $(pwd)/travis/stashcache-origin-config/10-origin-authfile.cfg:/etc/xrootd/config.d/10-origin-authfile.cfg \
        --volume $(pwd)/travis/stashcache-origin-config/authfile:/etc/xrootd/public-origin-authfile \
-       --volume $(pwd)/travis/stashcache-origin-config/test_file:/tmp/stashcache-travis-ci-test/test_file \
+       --volume $(pwd)/travis/stashcache-origin-config/test_file:/origin/test_file \
        --name test_origin opensciencegrid/stash-origin:fresh &
 docker ps 
 sleep 20
 
-online_md5="$(curl -sL http://localhost:1094/stashcache-travis-ci-test/test_file | md5sum | cut -d ' ' -f 1)"
+online_md5="$(curl -sL http://localhost:1094/test_file | md5sum | cut -d ' ' -f 1)"
 local_md5="$(md5sum $(pwd)/travis/stashcache-origin-config/test_file | cut -d ' ' -f 1)"
 if [ "$online_md5" != "$local_md5" ]; then
     echo "MD5sums do not match on origin"


### PR DESCRIPTION
Since nobody actually cares where the data lives inside the container, we should just tell users where to mount their host partition that actually contains the data.

This change will continue to respect any `XC_ORIGINEXPORT` variables that users may have set but I highly suspect that no one has actually used this outside of OSG staff since the existing documentation doesn't seem like it would work.