### PR TITLE
Add builds for upcoming using GitHub actions (SOFTWARE-4181)

### DIFF
--- a/.github/Dockerfile.dummy
+++ b/.github/Dockerfile.dummy
@@ -1,0 +1,8 @@
+# Dummy Dockerfile for pushing built and tested images
+# FIXME: Remove this and update the workflows after this feature is
+# implemented
+# https://github.com/docker/build-push-action/issues/17
+ARG IMAGE_NAME
+ARG TAG_NAME
+
+FROM "opensciencegrid/$IMAGE_NAME" "xcache:$TAG_NAME"

--- a/.github/Dockerfile.dummy
+++ b/.github/Dockerfile.dummy
@@ -1,8 +1,0 @@
-# Dummy Dockerfile for pushing built and tested images
-# FIXME: Remove this and update the workflows after this feature is
-# implemented
-# https://github.com/docker/build-push-action/issues/17
-ARG IMAGE_NAME
-ARG TAG_NAME
-
-FROM ${IMAGE_NAME}:${TAG_NAME}

--- a/.github/Dockerfile.dummy
+++ b/.github/Dockerfile.dummy
@@ -5,4 +5,4 @@
 ARG IMAGE_NAME
 ARG TAG_NAME
 
-FROM "opensciencegrid/$IMAGE_NAME" "xcache:$TAG_NAME"
+FROM ${IMAGE_NAME}:${TAG_NAME}

--- a/.github/workflows/release-image-builds.yml
+++ b/.github/workflows/release-image-builds.yml
@@ -96,5 +96,5 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           dockerfile: ./.github/Dockerfile.dummy
-          build_args: IMAGE_NAME=${{ matrix.yum_repo_prefix }}, TAG_NAME=${{ matrix.yum_repo_prefix }}minefield
+          build_args: IMAGE_NAME=docker.pkg.github.com/${{ github.repository }}/${{ matrix.image }}, TAG_NAME=${{ matrix.yum_repo_prefix }}minefield
           tags: ${{ matrix.yum_repo_prefix }}fresh, ${{ matrix.yum_repo_prefix }}${{ needs.get-timestamp.outputs.timestamp }}

--- a/.github/workflows/release-image-builds.yml
+++ b/.github/workflows/release-image-builds.yml
@@ -88,6 +88,8 @@ jobs:
     steps:
       - name: Check out docker-xcache
         uses: actions/checkout@v2
+      - name: Create dummy Dockerfile
+        run: echo "FROM docker.pkg.github.com/$GITHUB_REPOSITORY/${{ matrix.image }}:${{ matrix.yum_repo_prefix }}minefield" > Dockerfile
       - run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
       - name: Build ${{ matrix.image}} image
         uses: docker/build-push-action@v1
@@ -95,6 +97,4 @@ jobs:
           repository: brianhlin/${{ matrix.image }}
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          dockerfile: ./.github/Dockerfile.dummy
-          build_args: IMAGE_NAME=docker.pkg.github.com/${{ github.repository }}/${{ matrix.image }}, TAG_NAME=${{ matrix.yum_repo_prefix }}minefield
           tags: ${{ matrix.yum_repo_prefix }}fresh, ${{ matrix.yum_repo_prefix }}${{ needs.get-timestamp.outputs.timestamp }}

--- a/.github/workflows/release-image-builds.yml
+++ b/.github/workflows/release-image-builds.yml
@@ -80,3 +80,10 @@ jobs:
           path: ./${{ matrix.image }}
           build_args: BASE_YUM_REPO=osg-${{ matrix.yum_repo_prefix }}minefield
           tags: ${{ matrix.yum_repo_prefix }}fresh
+      - name: Save ${{ matrix.image }}:${{ matrix.yum_repo_prefix}}fresh image
+        run: docker save --output /tmp/${{ matrix.image }}.tar brianhlin/${{ matrix.image }}:${{ matrix.yum_repo_prefix }}fresh
+      - name: Upload ${{ matrix.image }}:${{ matrix.yum_repo_prefix}}fresh artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.image }}-image-${{ matrix.yum_repo_prefix }}fresh
+          path: /tmp/${{ matrix.image }}.tar

--- a/.github/workflows/release-image-builds.yml
+++ b/.github/workflows/release-image-builds.yml
@@ -8,32 +8,15 @@ on:
   #   - cron: '34 2 * * TUE'
 
 jobs:
-  clone-repo:
-    name: Clone the repo for the subsequent jobs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out docker-xcache
-        uses: actions/checkout@v2
-        with:
-          path: docker-xcache
-          fetch-depth: 1
-      - name: Upload docker-xcache repo artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: docker-xcache-repo
-          path: ./docker-xcache
   base-image-build:
     name: Build initial xcache:${{ matrix.yum_repo_prefix }}fresh base image
-    needs: clone-repo
     strategy:
       matrix:
         yum_repo_prefix: ["upcoming-", ""]
     runs-on: ubuntu-latest
     steps:
-      - name: Download docker-xcache
-        uses: actions/download-artifact@v2
-        with:
-          name: docker-xcache-repo
+      - name: Check out docker-xcache
+        uses: actions/checkout@v2
       - name: Build XCache base image
         uses: docker/build-push-action@v1
         with:
@@ -53,10 +36,8 @@ jobs:
     needs: base-image-build
     runs-on: ubuntu-latest
     steps:
-      - name: Download docker-xcache
-        uses: actions/download-artifact@v2
-        with:
-          name: docker-xcache-repo
+      - name: Check out docker-xcache
+        uses: actions/checkout@v2
       - name: Replace FROM line in Dockerfile
         working-directory: ${{ matrix.image }}
         run: |
@@ -81,9 +62,8 @@ jobs:
     needs: xcache-image-builds
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: docker-xcache-repo
+      - name: Check out docker-xcache
+        uses: actions/checkout@v2
       - run: ./tests/test_stashcache_origin.sh "docker.pkg.github.com/$GITHUB_REPOSITORY/stash-origin:${{ matrix.yum_repo_prefix }}minefield"
       - run: ./tests/test_stashcache.sh "docker.pkg.github.com/$GITHUB_REPOSITORY/stash-cache:${{ matrix.yum_repo_prefix }}minefield"
   get-timestamp:

--- a/.github/workflows/release-image-builds.yml
+++ b/.github/workflows/release-image-builds.yml
@@ -8,8 +8,18 @@ on:
       - master
 
 jobs:
+  get-timestamp:
+    name: Get timestamp for tagging images
+    runs-on: ubuntu-latest
+    outputs:
+      dtag: ${{ steps.timestamp-tag.outputs.dtag }}
+    steps:
+      - name: Get timestamp for timestamp tags
+        id: timestamp-tag
+        run: echo "::set-output name=dtag::$(date +%Y%m%d-%H%M)"
   base-image-build:
     name: Build initial xcache:${{ matrix.yum_repo_prefix }}fresh base image
+    needs: get-timestamp
     strategy:
       matrix:
         yum_repo_prefix: ["upcoming-", ""]
@@ -26,14 +36,16 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           path: ./xcache
           build_args: BASE_YUM_REPO=osg-${{ matrix.yum_repo_prefix }}minefield
-          tags: ${{ matrix.yum_repo_prefix }}minefield
+          tags: ${{ matrix.yum_repo_prefix }}minefield-${{ needs.get-timestamp.outputs.dtag }}
   xcache-image-builds:
     name: Build ${{ matrix.image }}:${{ matrix.yum_repo_prefix}}fresh image
     strategy:
       matrix:
         image: [atlas-xcache, cms-xcache, stash-cache, stash-origin]
         yum_repo_prefix: ["upcoming-", ""]
-    needs: base-image-build
+    needs:
+      - get-timestamp
+      - base-image-build
     runs-on: ubuntu-latest
     steps:
       - name: Check out docker-xcache
@@ -42,7 +54,7 @@ jobs:
         working-directory: ${{ matrix.image }}
         run: |
           sed -i \
-            "s|FROM opensciencegrid/xcache:fresh|FROM docker.pkg.github.com/$GITHUB_REPOSITORY/xcache:${{ matrix.yum_repo_prefix}}minefield|" \
+            "s|FROM opensciencegrid/xcache:fresh|FROM docker.pkg.github.com/$GITHUB_REPOSITORY/xcache:${{ matrix.yum_repo_prefix}}minefield-${{ needs.get-timestamp.outputs.dtag }}|" \
             Dockerfile
       - name: Build ${{ matrix.image }}:${{ matrix.yum_repo_prefix }}fresh image
         uses: docker/build-push-action@v1
@@ -53,9 +65,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           path: ${{ matrix.image }}
           build_args: BASE_YUM_REPO=osg-${{ matrix.yum_repo_prefix }}minefield
-          tags: ${{ matrix.yum_repo_prefix }}minefield
+          tags: ${{ matrix.yum_repo_prefix }}minefield$-{{ needs.get-timestamp.outputs.dtag }}
   test-stash-cache:
     name: Test Stash Cache and Origin (${{ matrix.yum_repo_prefix }}fresh)
+    needs:
+      - get-timestamp
+      - xcache-image-builds
     strategy:
       matrix:
         yum_repo_prefix: ["upcoming-", ""]
@@ -65,18 +80,8 @@ jobs:
       - name: Check out docker-xcache
         uses: actions/checkout@v2
       - run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
-      - run: ./tests/test_stashcache_origin.sh "docker.pkg.github.com/$GITHUB_REPOSITORY/stash-origin:${{ matrix.yum_repo_prefix }}minefield"
-      - run: ./tests/test_stashcache.sh "docker.pkg.github.com/$GITHUB_REPOSITORY/stash-cache:${{ matrix.yum_repo_prefix }}minefield"
-  get-timestamp:
-    name: Get timestamp for tagging images
-    needs: test-stash-cache
-    runs-on: ubuntu-latest
-    outputs:
-      timestamp: ${{ steps.timestamp-tag.outputs.timestamp }}
-    steps:
-      - name: Get timestamp for timestamp tags
-        id: timestamp-tag
-        run: echo "::set-output name=timestamp::$(date +%Y%m%d-%H%M)"
+      - run: ./tests/test_stashcache_origin.sh "docker.pkg.github.com/$GITHUB_REPOSITORY/stash-origin:${{ matrix.yum_repo_prefix }}minefield-${{ needs.get-timestamp.outputs.dtag }}"
+      - run: ./tests/test_stashcache.sh "docker.pkg.github.com/$GITHUB_REPOSITORY/stash-cache:${{ matrix.yum_repo_prefix }}minefield-${{ needs.get-timestamp.outputs.dtag }}"
   push-images:
     name: Push ${{ matrix.image }}:${{ matrix.yum_repo_prefix }}fresh image
     if: github.event_name == 'push'
@@ -84,15 +89,17 @@ jobs:
       matrix:
         image: [atlas-xcache, cms-xcache, stash-cache, stash-origin, xcache]
         yum_repo_prefix: ["upcoming-", ""]
-    needs: get-timestamp
+    needs:
+      - get-timestamp
+      - test-stash-cache
     runs-on: ubuntu-latest
     steps:
       - name: Check out docker-xcache
         uses: actions/checkout@v2
       - name: Create dummy Dockerfile
-        run: echo "FROM docker.pkg.github.com/$GITHUB_REPOSITORY/${{ matrix.image }}:${{ matrix.yum_repo_prefix }}minefield" > Dockerfile
+        run: echo "FROM docker.pkg.github.com/$GITHUB_REPOSITORY/${{ matrix.image }}:${{ matrix.yum_repo_prefix }}minefield-${{ needs.get-timestamp.outputs.dtag }}" > Dockerfile
       - run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
-      - run: docker pull docker.pkg.github.com/$GITHUB_REPOSITORY/${{ matrix.image }}:${{ matrix.yum_repo_prefix }}minefield
+      - run: docker pull docker.pkg.github.com/$GITHUB_REPOSITORY/${{ matrix.image }}:${{ matrix.yum_repo_prefix }}minefield-${{ needs.get-timestamp.outputs.dtag }}
       - name: Build ${{ matrix.image}} image
         uses: docker/build-push-action@v1
         with:

--- a/.github/workflows/release-image-builds.yml
+++ b/.github/workflows/release-image-builds.yml
@@ -91,6 +91,7 @@ jobs:
       - name: Create dummy Dockerfile
         run: echo "FROM docker.pkg.github.com/$GITHUB_REPOSITORY/${{ matrix.image }}:${{ matrix.yum_repo_prefix }}minefield" > Dockerfile
       - run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
+      - run: docker pull docker.pkg.github.com/$GITHUB_REPOSITORY/${{ matrix.image }}:${{ matrix.yum_repo_prefix }}minefield
       - name: Build ${{ matrix.image}} image
         uses: docker/build-push-action@v1
         with:

--- a/.github/workflows/release-image-builds.yml
+++ b/.github/workflows/release-image-builds.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   base-image-build:
@@ -76,6 +79,7 @@ jobs:
         run: echo "::set-output name=timestamp::$(date +%Y%m%d-%H%M)"
   push-images:
     name: Push ${{ matrix.image }}:${{ matrix.yum_repo_prefix }}fresh image
+    if: github.event_name == 'push'
     strategy:
       matrix:
         image: [atlas-xcache, cms-xcache, stash-cache, stash-origin, xcache]

--- a/.github/workflows/release-image-builds.yml
+++ b/.github/workflows/release-image-builds.yml
@@ -38,18 +38,13 @@ jobs:
       - name: Build XCache base image
         uses: docker/build-push-action@v1
         with:
-          repository: brianhlin/xcache
+          repository: ${{ github.repository }}/xcache
+          registry: docker.pkg.github.com
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
           path: ./xcache
-          push: false
           build_args: BASE_YUM_REPO=osg-${{ matrix.yum_repo_prefix }}minefield
-          tags: ${{ matrix.yum_repo_prefix }}fresh
-      - name: Save xcache:${{ matrix.yum_repo_prefix }}fresh image
-        run: docker save --output /tmp/xcache.tar brianhlin/xcache:${{ matrix.yum_repo_prefix }}fresh
-      - name: Upload xcache:${{ matrix.yum_repo_prefix }}fresh image artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: xcache-image-${{ matrix.yum_repo_prefix }}fresh
-          path: /tmp/xcache.tar
+          tags: ${{ matrix.yum_repo_prefix }}minefield
   xcache-image-builds:
     name: Build ${{ matrix.image }}:${{ matrix.yum_repo_prefix}}fresh image
     strategy:
@@ -63,30 +58,22 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: docker-xcache-repo
-      - name: Download XCache base image artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: xcache-image-${{ matrix.yum_repo_prefix }}fresh
-      - name: Load XCache base image
-        run: docker load -i xcache.tar
       - name: Replace FROM line in Dockerfile
         working-directory: ${{ matrix.image }}
-        run: sed -i "s|FROM opensciencegrid/xcache:fresh|FROM brianhlin/xcache:${{ matrix.yum_repo_prefix}}fresh|" Dockerfile
-      - name: Build ${{ matrix.image}} image
+        run: |
+          sed -i \
+            "s|FROM opensciencegrid/xcache:fresh|FROM docker.pkg.github.com/$GITHUB_REPOSITORY/xcache:${{ matrix.yum_repo_prefix}}minefield|" \
+            Dockerfile
+      - name: Build ${{ matrix.image }}:${{ matrix.yum_repo_prefix }}fresh image
         uses: docker/build-push-action@v1
         with:
-          repository: brianhlin/${{ matrix.image }}
-          push: false
-          path: ./${{ matrix.image }}
+          repository: ${{ github.repository }}/${{ matrix.image }}
+          registry: docker.pkg.github.com
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          path: ${{ matrix.image }}
           build_args: BASE_YUM_REPO=osg-${{ matrix.yum_repo_prefix }}minefield
-          tags: ${{ matrix.yum_repo_prefix }}fresh
-      - name: Save ${{ matrix.image }}:${{ matrix.yum_repo_prefix}}fresh image
-        run: docker save --output /tmp/${{ matrix.image }}.tar brianhlin/${{ matrix.image }}:${{ matrix.yum_repo_prefix }}fresh
-      - name: Upload ${{ matrix.image }}:${{ matrix.yum_repo_prefix}}fresh artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.image }}-image-${{ matrix.yum_repo_prefix }}fresh
-          path: /tmp/${{ matrix.image }}.tar
+          tags: ${{ matrix.yum_repo_prefix }}minefield
   test-stash-cache:
     name: Test Stash Cache and Origin (${{ matrix.yum_repo_prefix }}fresh)
     strategy:
@@ -127,12 +114,6 @@ jobs:
     needs: get-timestamp
     runs-on: ubuntu-latest
     steps:
-      - name: Download ${{ matrix.image }}:${{ matrix.yum_repo_prefix }}fresh
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ matrix.image }}-image-${{ matrix.yum_repo_prefix }}fresh
-      - name: Load ${{ matrix.image }}:${{ matrix.yum_repo_prefix }}fresh image
-        run: docker load -i ${{ matrix.image }}.tar
       - name: Build ${{ matrix.image}} image
         uses: docker/build-push-action@v1
         with:
@@ -140,5 +121,5 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           path: ./.github/Dockerfile.dummy
-          build_args: IMAGE_NAME=${{ matrix.yum_repo_prefix }}, TAG_NAME=${{ matrix.yum_repo_prefix }}fresh
+          build_args: IMAGE_NAME=${{ matrix.yum_repo_prefix }}, TAG_NAME=${{ matrix.yum_repo_prefix }}minefield
           tags: ${{ matrix.yum_repo_prefix }}fresh, ${{ matrix.yum_repo_prefix }}${{ needs.get-timestamp.outputs.timestamp }}

--- a/.github/workflows/release-image-builds.yml
+++ b/.github/workflows/release-image-builds.yml
@@ -95,6 +95,6 @@ jobs:
           repository: brianhlin/${{ matrix.image }}
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          path: ./.github/Dockerfile.dummy
+          dockerfile: ./.github/Dockerfile.dummy
           build_args: IMAGE_NAME=${{ matrix.yum_repo_prefix }}, TAG_NAME=${{ matrix.yum_repo_prefix }}minefield
           tags: ${{ matrix.yum_repo_prefix }}fresh, ${{ matrix.yum_repo_prefix }}${{ needs.get-timestamp.outputs.timestamp }}

--- a/.github/workflows/release-image-builds.yml
+++ b/.github/workflows/release-image-builds.yml
@@ -87,3 +87,24 @@ jobs:
         with:
           name: ${{ matrix.image }}-image-${{ matrix.yum_repo_prefix }}fresh
           path: /tmp/${{ matrix.image }}.tar
+  test-stash-cache:
+    name: Test Stash Cache and Origin (${{ matrix.yum_repo_prefix }}fresh)
+    strategy:
+      matrix:
+        yum_repo_prefix: ["upcoming-", ""]
+    needs: xcache-image-builds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: docker-xcache-repo
+      - uses: actions/download-artifact@v2
+        with:
+          name: stash-cache-image-${{ matrix.yum_repo_prefix }}fresh
+      - uses: actions/download-artifact@v2
+        with:
+          name: stash-origin-image-${{ matrix.yum_repo_prefix }}fresh
+      - run: docker load -i stash-cache.tar
+      - run: docker load -i stash-origin.tar
+      - run: ./tests/test_stashcache_origin.sh
+      - run: ./tests/test_stashcache.sh

--- a/.github/workflows/release-image-builds.yml
+++ b/.github/workflows/release-image-builds.yml
@@ -84,16 +84,8 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: docker-xcache-repo
-      - uses: actions/download-artifact@v2
-        with:
-          name: stash-cache-image-${{ matrix.yum_repo_prefix }}fresh
-      - uses: actions/download-artifact@v2
-        with:
-          name: stash-origin-image-${{ matrix.yum_repo_prefix }}fresh
-      - run: docker load -i stash-cache.tar
-      - run: docker load -i stash-origin.tar
-      - run: ./tests/test_stashcache_origin.sh
-      - run: ./tests/test_stashcache.sh
+      - run: ./tests/test_stashcache_origin.sh "docker.pkg.github.com/$GITHUB_REPOSITORY/stash-origin:${{ matrix.yum_repo_prefix }}minefield"
+      - run: ./tests/test_stashcache.sh "docker.pkg.github.com/$GITHUB_REPOSITORY/stash-cache:${{ matrix.yum_repo_prefix }}minefield"
   get-timestamp:
     name: Get timestamp for tagging images
     needs: test-stash-cache

--- a/.github/workflows/release-image-builds.yml
+++ b/.github/workflows/release-image-builds.yml
@@ -86,6 +86,8 @@ jobs:
     needs: get-timestamp
     runs-on: ubuntu-latest
     steps:
+      - name: Check out docker-xcache
+        uses: actions/checkout@v2
       - run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
       - name: Build ${{ matrix.image}} image
         uses: docker/build-push-action@v1

--- a/.github/workflows/release-image-builds.yml
+++ b/.github/workflows/release-image-builds.yml
@@ -50,40 +50,33 @@ jobs:
         with:
           name: xcache-image-${{ matrix.yum_repo_prefix }}fresh
           path: /tmp/xcache.tar
-  # xcache-image-builds:
-  #   name: Build ${{ matrix.image }} images
-  #   strategy:
-  #     matrix:
-  #       image: [atlas-xcache, cms-xcache, stash-cache, stash-origin]
-  #       yum_repo_repo: ["upcoming-", ""]
-  #   needs:
-  #     - base-image-build
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Get timestamp
-  #       id: timestamp
-  #       run: echo "::set-output name=timestamp::$(date +%Y%m%d-%H%M)"
-  #     - name: Download docker-xcache
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         name: docker-xcache-repo
-  #     - name: Download XCache base image artifact
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         name: xcache-image
-  #     - name: Load XCache base image
-  #       run: docker load -i xcache.tar
-  #     - name: Replace FROM line in Dockerfile
-  #       working-directory: ${{ matrix.image }}
-  #       run: sed -i "s|FROM opensciencegrid/xcache:fresh|FROM brianhlin/xcache:${{ needs.xrootd-rpm-build.outputs.tags }}|" Dockerfile
-  #     - name: Build ${{ matrix.image}} image
-  #       uses: docker/build-push-action@v1
-  #       with:
-  #         repository: brianhlin/${{ matrix.image }}
-  #         username: ${{ secrets.DOCKER_USERNAME }}
-  #         password: ${{ secrets.DOCKER_PASSWORD }}
-  #         path: ./${{ matrix.image }}
-  #         tags: ${{ needs.xrootd-rpm-build.outputs.tags }}
-  #   # TODO: Add test jobs or steps here and sandwich them between
-  #   # separated image build and push. Also, push XCache base image.
-
+  xcache-image-builds:
+    name: Build ${{ matrix.image }}:${{ matrix.yum_repo_prefix}}fresh image
+    strategy:
+      matrix:
+        image: [atlas-xcache, cms-xcache, stash-cache, stash-origin]
+        yum_repo_prefix: ["upcoming-", ""]
+    needs: base-image-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download docker-xcache
+        uses: actions/download-artifact@v2
+        with:
+          name: docker-xcache-repo
+      - name: Download XCache base image artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: xcache-image-${{ matrix.yum_repo_prefix }}fresh
+      - name: Load XCache base image
+        run: docker load -i xcache.tar
+      - name: Replace FROM line in Dockerfile
+        working-directory: ${{ matrix.image }}
+        run: sed -i "s|FROM opensciencegrid/xcache:fresh|FROM brianhlin/xcache:${{ matrix.yum_repo_prefix}}fresh|" Dockerfile
+      - name: Build ${{ matrix.image}} image
+        uses: docker/build-push-action@v1
+        with:
+          repository: brianhlin/${{ matrix.image }}
+          push: false
+          path: ./${{ matrix.image }}
+          build_args: BASE_YUM_REPO=osg-${{ matrix.yum_repo_prefix }}minefield
+          tags: ${{ matrix.yum_repo_prefix }}fresh

--- a/.github/workflows/release-image-builds.yml
+++ b/.github/workflows/release-image-builds.yml
@@ -9,11 +9,8 @@ on:
   #   - cron: '34 2 * * TUE'
 
 jobs:
-  base-image-build:
-    name: Build initial xcache ${{ matrix.yum_repo_prefix }}fresh base image
-    strategy:
-      matrix:
-        yum_repo_prefix: ["upcoming-", ""]
+  clone-repo:
+    name: Clone the repo for the subsequent jobs
     runs-on: ubuntu-latest
     steps:
       - name: Check out docker-xcache
@@ -21,6 +18,23 @@ jobs:
         with:
           path: docker-xcache
           fetch-depth: 1
+      - name: Upload docker-xcache repo artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: docker-xcache-repo
+          path: ./docker-xcache
+  base-image-build:
+    name: Build initial xcache ${{ matrix.yum_repo_prefix }}fresh base image
+    needs: clone-repo
+    strategy:
+      matrix:
+        yum_repo_prefix: ["upcoming-", ""]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download docker-xcache
+        uses: actions/download-artifact@v2
+        with:
+          name: docker-xcache-repo
       - name: Build XCache base image
         uses: docker/build-push-action@v1
         with:

--- a/.github/workflows/release-image-builds.yml
+++ b/.github/workflows/release-image-builds.yml
@@ -108,3 +108,37 @@ jobs:
       - run: docker load -i stash-origin.tar
       - run: ./tests/test_stashcache_origin.sh
       - run: ./tests/test_stashcache.sh
+  get-timestamp:
+    name: Get timestamp for tagging images
+    needs: test-stash-cache
+    runs-on: ubuntu-latest
+    outputs:
+      timestamp: ${{ steps.timestamp-tag.outputs.timestamp }}
+    steps:
+      - name: Get timestamp for timestamp tags
+        id: timestamp-tag
+        run: echo "::set-output name=timestamp::$(date +%Y%m%d-%H%M)"
+  push-images:
+    name: Push ${{ matrix.image }}:${{ matrix.yum_repo_prefix }}fresh image
+    strategy:
+      matrix:
+        image: [atlas-xcache, cms-xcache, stash-cache, stash-origin, xcache]
+        yum_repo_prefix: ["upcoming-", ""]
+    needs: get-timestamp
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download ${{ matrix.image }}:${{ matrix.yum_repo_prefix }}fresh
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.image }}-image-${{ matrix.yum_repo_prefix }}fresh
+      - name: Load ${{ matrix.image }}:${{ matrix.yum_repo_prefix }}fresh image
+        run: docker load -i ${{ matrix.image }}.tar
+      - name: Build ${{ matrix.image}} image
+        uses: docker/build-push-action@v1
+        with:
+          repository: brianhlin/${{ matrix.image }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          path: ./.github/Dockerfile.dummy
+          build_args: IMAGE_NAME=${{ matrix.yum_repo_prefix }}, TAG_NAME=${{ matrix.yum_repo_prefix }}fresh
+          tags: ${{ matrix.yum_repo_prefix }}fresh, ${{ matrix.yum_repo_prefix }}${{ needs.get-timestamp.outputs.timestamp }}

--- a/.github/workflows/release-image-builds.yml
+++ b/.github/workflows/release-image-builds.yml
@@ -2,8 +2,7 @@ name: Build XCache images from OSG Yum repositories
 on:
   push:
     branches:
-      - master
-      - SOFTWARE-4181.upcoming-containers
+      - SOFTWARE-4181.github-docker-repo
   # TODO: Change to every 5 minutes once we filter out already-built tags
   # schedule:
   #   - cron: '34 2 * * TUE'

--- a/.github/workflows/release-image-builds.yml
+++ b/.github/workflows/release-image-builds.yml
@@ -2,10 +2,7 @@ name: Build XCache images from OSG Yum repositories
 on:
   push:
     branches:
-      - SOFTWARE-4181.github-docker-repo
-  # TODO: Change to every 5 minutes once we filter out already-built tags
-  # schedule:
-  #   - cron: '34 2 * * TUE'
+      - master
 
 jobs:
   base-image-build:
@@ -95,7 +92,7 @@ jobs:
       - name: Build ${{ matrix.image}} image
         uses: docker/build-push-action@v1
         with:
-          repository: brianhlin/${{ matrix.image }}
+          repository: opensciencegrid/${{ matrix.image }}
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           tags: ${{ matrix.yum_repo_prefix }}fresh, ${{ matrix.yum_repo_prefix }}${{ needs.get-timestamp.outputs.timestamp }}

--- a/.github/workflows/release-image-builds.yml
+++ b/.github/workflows/release-image-builds.yml
@@ -64,6 +64,7 @@ jobs:
     steps:
       - name: Check out docker-xcache
         uses: actions/checkout@v2
+      - run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
       - run: ./tests/test_stashcache_origin.sh "docker.pkg.github.com/$GITHUB_REPOSITORY/stash-origin:${{ matrix.yum_repo_prefix }}minefield"
       - run: ./tests/test_stashcache.sh "docker.pkg.github.com/$GITHUB_REPOSITORY/stash-cache:${{ matrix.yum_repo_prefix }}minefield"
   get-timestamp:
@@ -85,6 +86,7 @@ jobs:
     needs: get-timestamp
     runs-on: ubuntu-latest
     steps:
+      - run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
       - name: Build ${{ matrix.image}} image
         uses: docker/build-push-action@v1
         with:

--- a/.github/workflows/release-image-builds.yml
+++ b/.github/workflows/release-image-builds.yml
@@ -24,7 +24,7 @@ jobs:
           name: docker-xcache-repo
           path: ./docker-xcache
   base-image-build:
-    name: Build initial xcache ${{ matrix.yum_repo_prefix }}fresh base image
+    name: Build initial xcache:${{ matrix.yum_repo_prefix }}fresh base image
     needs: clone-repo
     strategy:
       matrix:
@@ -43,9 +43,9 @@ jobs:
           push: false
           build_args: BASE_YUM_REPO=osg-${{ matrix.yum_repo_prefix }}minefield
           tags: ${{ matrix.yum_repo_prefix }}fresh
-      - name: Save XCache base image
+      - name: Save xcache:${{ matrix.yum_repo_prefix }}fresh image
         run: docker save --output /tmp/xcache.tar brianhlin/xcache:${{ matrix.yum_repo_prefix }}fresh
-      - name: Upload XCache ${{ matrix.yum_repo_prefix }}fresh image artifact
+      - name: Upload xcache:${{ matrix.yum_repo_prefix }}fresh image artifact
         uses: actions/upload-artifact@v2
         with:
           name: xcache-image-${{ matrix.yum_repo_prefix }}fresh

--- a/.github/workflows/release-image-builds.yml
+++ b/.github/workflows/release-image-builds.yml
@@ -1,0 +1,75 @@
+name: Build XCache images from OSG Yum repositories
+on:
+  push:
+    branches:
+      - master
+      - SOFTWARE-4181.upcoming-containers
+  # TODO: Change to every 5 minutes once we filter out already-built tags
+  # schedule:
+  #   - cron: '34 2 * * TUE'
+
+jobs:
+  base-image-build:
+    name: Build initial xcache ${{ matrix.yum_repo_prefix }}fresh base image
+    strategy:
+      matrix:
+        yum_repo_prefix: ["upcoming-", ""]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out docker-xcache
+        uses: actions/checkout@v2
+        with:
+          path: docker-xcache
+          fetch-depth: 1
+      - name: Build XCache base image
+        uses: docker/build-push-action@v1
+        with:
+          repository: brianhlin/xcache
+          path: ./xcache
+          push: false
+          build_args: BASE_YUM_REPO=osg-${{ matrix.yum_repo_prefix }}minefield
+          tags: ${{ matrix.yum_repo_prefix }}fresh
+      - name: Save XCache base image
+        run: docker save --output /tmp/xcache.tar brianhlin/xcache:${{ matrix.yum_repo_prefix }}fresh
+      - name: Upload XCache ${{ matrix.yum_repo_prefix }}fresh image artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: xcache-image-${{ matrix.yum_repo_prefix }}fresh
+          path: /tmp/xcache.tar
+  # xcache-image-builds:
+  #   name: Build ${{ matrix.image }} images
+  #   strategy:
+  #     matrix:
+  #       image: [atlas-xcache, cms-xcache, stash-cache, stash-origin]
+  #       yum_repo_repo: ["upcoming-", ""]
+  #   needs:
+  #     - base-image-build
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Get timestamp
+  #       id: timestamp
+  #       run: echo "::set-output name=timestamp::$(date +%Y%m%d-%H%M)"
+  #     - name: Download docker-xcache
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: docker-xcache-repo
+  #     - name: Download XCache base image artifact
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: xcache-image
+  #     - name: Load XCache base image
+  #       run: docker load -i xcache.tar
+  #     - name: Replace FROM line in Dockerfile
+  #       working-directory: ${{ matrix.image }}
+  #       run: sed -i "s|FROM opensciencegrid/xcache:fresh|FROM brianhlin/xcache:${{ needs.xrootd-rpm-build.outputs.tags }}|" Dockerfile
+  #     - name: Build ${{ matrix.image}} image
+  #       uses: docker/build-push-action@v1
+  #       with:
+  #         repository: brianhlin/${{ matrix.image }}
+  #         username: ${{ secrets.DOCKER_USERNAME }}
+  #         password: ${{ secrets.DOCKER_PASSWORD }}
+  #         path: ./${{ matrix.image }}
+  #         tags: ${{ needs.xrootd-rpm-build.outputs.tags }}
+  #   # TODO: Add test jobs or steps here and sandwich them between
+  #   # separated image build and push. Also, push XCache base image.
+

--- a/atlas-xcache/Dockerfile
+++ b/atlas-xcache/Dockerfile
@@ -2,9 +2,12 @@ FROM opensciencegrid/xcache:fresh
 
 LABEL maintainer OSG Software <help@opensciencegrid.org>
 
+# Specify the base Yum repository to get the necessary RPMs
+ARG BASE_YUM_REPO
+
 ENV XC_IMAGE_NAME atlas-xcache
 
-RUN yum install -y atlas-xcache --enablerepo=osg-testing --enablerepo=osg-contrib && \
+RUN yum install -y atlas-xcache --enablerepo="$BASE_YUM_REPO" --enablerepo=osg-contrib && \
     yum install -y python3 python3-requests && \
     yum clean all --enablerepo=* && rm -rf /var/cache/
 

--- a/cms-xcache/Dockerfile
+++ b/cms-xcache/Dockerfile
@@ -2,9 +2,12 @@ FROM opensciencegrid/xcache:fresh
 
 LABEL maintainer OSG Software <help@opensciencegrid.org>
 
+# Specify the base Yum repository to get the necessary RPMs
+ARG BASE_YUM_REPO
+
 ENV XC_IMAGE_NAME cms-xcache
 
-RUN yum install -y --enablerepo=osg-testing  \
+RUN yum install -y --enablerepo="$BASE_YUM_REPO" \
                 cms-xcache \
                 xcache-consistency-check && \
     yum clean all --enablerepo=* && rm -rf /var/cache/

--- a/stash-cache/Dockerfile
+++ b/stash-cache/Dockerfile
@@ -2,9 +2,12 @@ FROM opensciencegrid/xcache:fresh
 
 LABEL maintainer OSG Software <help@opensciencegrid.org>
 
+# Specify the base Yum repository to get the necessary RPMs
+ARG BASE_YUM_REPO
+
 ENV XC_IMAGE_NAME stash-cache
 
-RUN yum -y install stash-cache --enablerepo=osg-testing && \
+RUN yum -y install stash-cache --enablerepo="$BASE_YUM_REPO" && \
     yum clean all --enablerepo=* && rm -rf /var/cache/
 
 ADD cron.d/* /etc/cron.d/

--- a/stash-origin/Dockerfile
+++ b/stash-origin/Dockerfile
@@ -2,9 +2,12 @@ FROM opensciencegrid/xcache:fresh
 
 LABEL maintainer OSG Software <help@opensciencegrid.org>
 
+# Specify the base Yum repository to get the necessary RPMs
+ARG BASE_YUM_REPO
+
 ENV XC_IMAGE_NAME stash-origin
 
-RUN yum -y install stash-origin --enablerepo=osg-minefield && \
+RUN yum -y install stash-origin --enablerepo="$BASE_YUM_REPO" && \
     yum clean all --enablerepo=* && rm -rf /var/cache/yum/
 
 ADD cron.d/* /etc/cron.d/

--- a/tests/test_stashcache.sh
+++ b/tests/test_stashcache.sh
@@ -1,12 +1,13 @@
 #!/bin/bash -x
 # Script for testing StashCache docker images
 
+TEST_IMAGE="$1"
 
 docker run --rm \
        --network="host" \
        --volume $(pwd)/tests/stashcache-cache-config/90-docker-ci.cfg:/etc/xrootd/config.d//90-docker-ci.cfg  \
        --volume $(pwd)/tests/stashcache-cache-config/Authfile:/run/stash-cache/Authfile \
-       --name test_cache opensciencegrid/stash-cache:fresh &
+       --name test_cache "$TEST_IMAGE" &
 docker ps 
 sleep 25
 curl -v -sL http://localhost:8000/test_file

--- a/tests/test_stashcache.sh
+++ b/tests/test_stashcache.sh
@@ -16,7 +16,7 @@ online_md5="$(curl -sL http://localhost:8000/test_file | md5sum | cut -d ' ' -f 
 local_md5="$(md5sum $(pwd)/tests/stashcache-origin-config/test_file | cut -d ' ' -f 1)"
 if [ "$online_md5" != "$local_md5" ]; then
     echo "MD5sums do not match on stashcache"
-    docker exec -it test_cache cat /var/log/xrootd/stash-cache/xrootd.log
+    docker exec test_cache cat /var/log/xrootd/stash-cache/xrootd.log
     docker stop test_cache
     exit 1
 fi

--- a/tests/test_stashcache.sh
+++ b/tests/test_stashcache.sh
@@ -9,7 +9,7 @@ docker run --rm \
        --volume $(pwd)/tests/stashcache-cache-config/Authfile:/run/stash-cache/Authfile \
        --name test_cache "$TEST_IMAGE" &
 docker ps 
-sleep 25
+sleep 45
 curl -v -sL http://localhost:8000/test_file
 
 online_md5="$(curl -sL http://localhost:8000/test_file | md5sum | cut -d ' ' -f 1)"

--- a/tests/test_stashcache_origin.sh
+++ b/tests/test_stashcache_origin.sh
@@ -17,7 +17,7 @@ online_md5="$(curl -sL http://localhost:1094/test_file | md5sum | cut -d ' ' -f 
 local_md5="$(md5sum $(pwd)/tests/stashcache-origin-config/test_file | cut -d ' ' -f 1)"
 if [ "$online_md5" != "$local_md5" ]; then
     echo "MD5sums do not match on origin"
-    docker exec -it test_cache cat /var/log/xrootd/stash-origin/xrootd.log
+    docker exec -it test_origin cat /var/log/xrootd/stash-origin/xrootd.log
     docker stop test_origin
     exit 1
 fi

--- a/tests/test_stashcache_origin.sh
+++ b/tests/test_stashcache_origin.sh
@@ -10,7 +10,7 @@ docker run --rm \
        --volume $(pwd)/tests/stashcache-origin-config/authfile:/etc/xrootd/public-origin-authfile \
        --volume $(pwd)/tests/stashcache-origin-config/test_file:/xcache/namespace/test_file \
        --name test_origin "$TEST_IMAGE" &
-sleep 20
+sleep 45
 docker ps
 
 online_md5="$(curl -sL http://localhost:1094/test_file | md5sum | cut -d ' ' -f 1)"

--- a/tests/test_stashcache_origin.sh
+++ b/tests/test_stashcache_origin.sh
@@ -10,13 +10,15 @@ docker run --rm \
        --volume $(pwd)/tests/stashcache-origin-config/authfile:/etc/xrootd/public-origin-authfile \
        --volume $(pwd)/tests/stashcache-origin-config/test_file:/xcache/namespace/test_file \
        --name test_origin "$TEST_IMAGE" &
-docker ps 
 sleep 20
+docker ps
 
 online_md5="$(curl -sL http://localhost:1094/test_file | md5sum | cut -d ' ' -f 1)"
 local_md5="$(md5sum $(pwd)/tests/stashcache-origin-config/test_file | cut -d ' ' -f 1)"
+
 if [ "$online_md5" != "$local_md5" ]; then
     echo "MD5sums do not match on origin"
+    docker exec test_origin ls -lR /var/log/xrootd/
     docker exec test_origin cat /var/log/xrootd/stash-origin/xrootd.log
     docker stop test_origin
     exit 1

--- a/tests/test_stashcache_origin.sh
+++ b/tests/test_stashcache_origin.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -x
 # Script for testing StashCache docker images
 
+TEST_IMAGE="$1"
 
 docker run --rm \
        --network="host" \
@@ -8,7 +9,7 @@ docker run --rm \
        --volume $(pwd)/tests/stashcache-origin-config/10-origin-authfile.cfg:/etc/xrootd/config.d/10-origin-authfile.cfg \
        --volume $(pwd)/tests/stashcache-origin-config/authfile:/etc/xrootd/public-origin-authfile \
        --volume $(pwd)/tests/stashcache-origin-config/test_file:/xcache/namespace/test_file \
-       --name test_origin opensciencegrid/stash-origin:fresh &
+       --name test_origin "$TEST_IMAGE" &
 docker ps 
 sleep 20
 

--- a/tests/test_stashcache_origin.sh
+++ b/tests/test_stashcache_origin.sh
@@ -17,7 +17,7 @@ online_md5="$(curl -sL http://localhost:1094/test_file | md5sum | cut -d ' ' -f 
 local_md5="$(md5sum $(pwd)/tests/stashcache-origin-config/test_file | cut -d ' ' -f 1)"
 if [ "$online_md5" != "$local_md5" ]; then
     echo "MD5sums do not match on origin"
-    docker exec -it test_origin cat /var/log/xrootd/stash-origin/xrootd.log
+    docker exec test_origin cat /var/log/xrootd/stash-origin/xrootd.log
     docker stop test_origin
     exit 1
 fi

--- a/travis/build_docker.sh
+++ b/travis/build_docker.sh
@@ -7,6 +7,7 @@ for repo in $DOCKER_REPOS; do
     docker build \
            -t $DOCKER_ORG/$repo:fresh \
            -t $DOCKER_ORG/$repo:$timestamp \
+           --build-arg BASE_YUM_REPO=osg-minefield \
            $repo
 done
 

--- a/travis/travis-wrapper.sh
+++ b/travis/travis-wrapper.sh
@@ -4,8 +4,8 @@
 timestamp=`date +%Y%m%d-%H%M`
 
 ./travis/build_docker.sh $timestamp
-./tests/test_stashcache_origin.sh
-./tests/test_stashcache.sh
+./tests/test_stashcache_origin.sh opensciencegrid/stash-origin:fresh
+./tests/test_stashcache.sh opensciencegrid/stash-cache:fresh
 
 if [[ $TRAVIS_REPO_SLUG == opensciencegrid/* ]]; then
     ./travis/push_docker.sh $timestamp

--- a/xcache/Dockerfile
+++ b/xcache/Dockerfile
@@ -2,6 +2,9 @@ FROM opensciencegrid/software-base:fresh
 
 LABEL maintainer OSG Software <help@opensciencegrid.org>
 
+# Specify the base Yum repository to get the necessary RPMs
+ARG BASE_YUM_REPO
+
 # Default root dir
 ENV XC_ROOTDIR /xcache/namespace
 
@@ -9,7 +12,7 @@ ENV XC_ROOTDIR /xcache/namespace
 RUN groupadd -o -g 10940 xrootd
 RUN useradd -o -u 10940 -g 10940 -s /bin/sh xrootd
 
-RUN yum -y install xcache --enablerepo=osg-testing && \
+RUN yum -y install xcache --enablerepo="$BASE_YUM_REPO" && \
     yum clean all --enablerepo=* && rm -rf /var/cache/yum/
 
 ADD cron.d/* /etc/cron.d/


### PR DESCRIPTION
Works here: https://github.com/brianhlin/docker-xcache/actions/runs/176294919

This workflow is a little complicated because:

1. We build the XCache base image then the VO-specific images afterwards
2. Test the images

So I'm using the GitHub container registry as an intermediary for images tagged as `minefield` to pass images between jobs in the workflow, which is faster than compressing and decompressing build artifacts and forward-looking since we don't have to worry about storage limits.

~Known issue: multiple pushes to master in a short time frame could result in race conditions.~