### PR TITLE
Add the ability to build XCache images based on XRootD hotfixes (SOFTWARE-4151)

### DIFF
--- a/.github/find-hotfix-tags.sh
+++ b/.github/find-hotfix-tags.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 tag_regex='v[0-9]+\.[0-9]+\.[0-9]+-hotfix-[A-Za-z]+'
-git tag -l | egrep $tag_regex > git_tags
+git tag -l | sort | egrep $tag_regex > git_tags
 
 token=$(curl -s \
              -H "Content-Type: application/json" \
@@ -13,6 +13,7 @@ curl -s \
      -H "Authorization: JWT ${token}" \
      https://hub.docker.com/v2/repositories/brianhlin/stash-cache/tags/?page_size=100 | \
     jq -r '.results|.[]|.name' | \
+    sort | \
     egrep $tag_regex > dockerhub_tags
 
 # cowardly only build one hotfix tag at a time

--- a/.github/find-hotfix-tags.sh
+++ b/.github/find-hotfix-tags.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 tag_regex='v[0-9]+\.[0-9]+\.[0-9]+-osghotfix-[A-Za-z]+'
-git tag -l | sort | egrep $tag_regex > git_tags
+git tag -l | sort | egrep -x "$tag_regex" > git_tags
 
 token=$(curl -s \
              -H "Content-Type: application/json" \

--- a/.github/find-hotfix-tags.sh
+++ b/.github/find-hotfix-tags.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+tag_regex='v[0-9]+\.[0-9]+\.[0-9]+-hotfix-[A-Za-z]+'
+git tag -l | egrep $tag_regex > git_tags
+
+token=$(curl -s \
+             -H "Content-Type: application/json" \
+             -X POST \
+             -d '{"username": "'${DOCKER_USERNAME}'", "password": "'${DOCKER_PASSWORD}'"}' \
+             https://hub.docker.com/v2/users/login/ | jq -r .token)
+
+curl -s \
+     -H "Authorization: JWT ${token}" \
+     https://hub.docker.com/v2/repositories/brianhlin/stash-cache/tags/?page_size=100 | \
+    jq -r '.results|.[]|.name' | \
+    egrep $tag_regex > dockerhub_tags
+
+# cowardly only build one hotfix tag at a time
+build_candidate=$(comm -23 git_tags dockerhub_tags | head -n 1)
+
+echo "::set-output name=tags::$build_candidate"

--- a/.github/find-hotfix-tags.sh
+++ b/.github/find-hotfix-tags.sh
@@ -18,4 +18,4 @@ curl -s \
 # cowardly only build one hotfix tag at a time
 build_candidate=$(comm -23 git_tags dockerhub_tags | head -n 1)
 
-echo "::set-output name=tags::$build_candidate"
+echo "::set-output name=tag::$build_candidate"

--- a/.github/find-hotfix-tags.sh
+++ b/.github/find-hotfix-tags.sh
@@ -7,14 +7,14 @@ token=$(curl -s \
              -H "Content-Type: application/json" \
              -X POST \
              -d '{"username": "'${DOCKER_USERNAME}'", "password": "'${DOCKER_PASSWORD}'"}' \
-             https://hub.docker.com/v2/users/login/ | jq -r .token)
+             "https://hub.docker.com/v2/users/login/" | jq -r .token)
 
 curl -s \
      -H "Authorization: JWT ${token}" \
-     https://hub.docker.com/v2/repositories/brianhlin/stash-cache/tags/?page_size=100 | \
+     "https://hub.docker.com/v2/repositories/brianhlin/stash-cache/tags/?page_size=100" | \
     jq -r '.results|.[]|.name' | \
     sort | \
-    egrep $tag_regex > dockerhub_tags
+    egrep -x "$tag_regex" > dockerhub_tags
 
 # cowardly only build one hotfix tag at a time
 build_candidate=$(comm -23 git_tags dockerhub_tags | head -n 1)

--- a/.github/find-hotfix-tags.sh
+++ b/.github/find-hotfix-tags.sh
@@ -3,10 +3,25 @@
 tag_regex='v[0-9]+\.[0-9]+\.[0-9]+-osghotfix-[A-Za-z]+'
 git tag -l | sort | egrep -x "$tag_regex" > git_tags
 
+mkjson () {
+  python -c '
+import sys
+import json
+
+def esplit(x):
+    return x.split("=", 1)
+
+data = dict(map(esplit, sys.argv[1:]))
+print(json.dumps(data, sort_keys=True))
+' "$@"
+}
+
+json_auth=$(mkjson username="$DOCKER_USERNAME" password="$DOCKER_PASSWORD")
+
 token=$(curl -s \
              -H "Content-Type: application/json" \
              -X POST \
-             -d '{"username": "'${DOCKER_USERNAME}'", "password": "'${DOCKER_PASSWORD}'"}' \
+             -d "$json_auth" \
              "https://hub.docker.com/v2/users/login/" | jq -r .token)
 
 curl -s \

--- a/.github/find-hotfix-tags.sh
+++ b/.github/find-hotfix-tags.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-tag_regex='v[0-9]+\.[0-9]+\.[0-9]+-hotfix-[A-Za-z]+'
+tag_regex='v[0-9]+\.[0-9]+\.[0-9]+-osghotfix-[A-Za-z]+'
 git tag -l | sort | egrep $tag_regex > git_tags
 
 token=$(curl -s \

--- a/.github/prep-hotfix-sources.sh
+++ b/.github/prep-hotfix-sources.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -x
+
+HOTFIX_TAG=$1
+REPO_PATH=$2
+SPEC_PATH=$3
+
+# Create OSG build dirs
+build_dir=$(pwd)/_build_dir
+for dirname in osg upstream; do
+    mkdir -p $build_dir/$dirname
+done
+
+version=$(echo "$HOTFIX_TAG" | sed "s/v\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/")
+# Remove illegal dashes in release string
+release=$(tr '-' '.' <<< 1.${HOTFIX_TAG#*-})
+sed "s/__VERSION__/$version/" "$SPEC_PATH" | \
+    sed "s/__RELEASE__/$release/" > \
+        $build_dir/osg/xrootd.spec
+
+cd $REPO_PATH
+git checkout "$HOTFIX_TAG"
+tarball_path=$build_dir/xrootd.tar.gz
+git archive --prefix=xrootd/ --format=tar.gz "$HOTFIX_TAG" > $tarball_path
+
+# absolute path here reflects the location of the tarball when mounted
+# in the osg-build container
+echo "/u/_build_dir/xrootd.tar.gz sha1sum=$(sha1sum $tarball_path | cut -d ' ' -f 1)" > \
+     $build_dir/upstream/developer.tarball.source
+
+# Fix ownership so that osg-build docker container can write to it
+# Default GHA user is unprivileged so we need sudo
+sudo chown -R 1000:1000 $build_dir

--- a/.github/prep-hotfix-sources.sh
+++ b/.github/prep-hotfix-sources.sh
@@ -11,7 +11,7 @@ mkdir -p "$build_dir/{osg,upstream}"
 [[ $HOTFIX_TAG =~ ^(v[0-9]+\.[0-9]+\.[0-9]+)-(.*) ]]
 version=${BASH_REMATCH[1]}
 # Remove illegal dashes in release string
-release=$(tr '-' '.' <<< 1.${HOTFIX_TAG#*-})
+release=${BASH_REMATCH[2]//-/.}
 sed -e "s/__VERSION__/$version/" \
     -e "s/__RELEASE__/$release/" "$SPEC_PATH" > \
         "$build_dir/osg/xrootd.spec"

--- a/.github/prep-hotfix-sources.sh
+++ b/.github/prep-hotfix-sources.sh
@@ -6,25 +6,26 @@ SPEC_PATH=$3
 
 # Create OSG build dirs
 build_dir=$PWD/_build_dir
-mkdir -p $build_dir/{osg,upstream}
+mkdir -p "$build_dir/{osg,upstream}"
 
-version=$(echo "$HOTFIX_TAG" | sed "s/v\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/")
+[[ $HOTFIX_TAG =~ ^(v[0-9]+\.[0-9]+\.[0-9]+)-(.*) ]]
+version=${BASH_REMATCH[1]}
 # Remove illegal dashes in release string
 release=$(tr '-' '.' <<< 1.${HOTFIX_TAG#*-})
 sed -e "s/__VERSION__/$version/" \
     -e "s/__RELEASE__/$release/" "$SPEC_PATH" > \
-        $build_dir/osg/xrootd.spec
+        "$build_dir/osg/xrootd.spec"
 
-cd $REPO_PATH
+cd "$REPO_PATH"
 git checkout "$HOTFIX_TAG"
 tarball_path=$build_dir/xrootd.tar.gz
-git archive --prefix=xrootd/ --format=tar.gz "$HOTFIX_TAG" > $tarball_path
+git archive --prefix=xrootd/ --format=tar.gz "$HOTFIX_TAG" > "$tarball_path"
 
 # absolute path here reflects the location of the tarball when mounted
 # in the osg-build container
 echo "/u/_build_dir/xrootd.tar.gz sha1sum=$(sha1sum $tarball_path | cut -d ' ' -f 1)" > \
-     $build_dir/upstream/developer.tarball.source
+     "$build_dir/upstream/developer.tarball.source"
 
 # Fix ownership so that osg-build docker container can write to it
 # Default GHA user is unprivileged so we need sudo
-sudo chown -R 1000:1000 $build_dir
+sudo chown -R 1000:1000 "$build_dir"

--- a/.github/prep-hotfix-sources.sh
+++ b/.github/prep-hotfix-sources.sh
@@ -5,16 +5,14 @@ REPO_PATH=$2
 SPEC_PATH=$3
 
 # Create OSG build dirs
-build_dir=$(pwd)/_build_dir
-for dirname in osg upstream; do
-    mkdir -p $build_dir/$dirname
-done
+build_dir=$PWD/_build_dir
+mkdir -p $build_dir/{osg,upstream}
 
 version=$(echo "$HOTFIX_TAG" | sed "s/v\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/")
 # Remove illegal dashes in release string
 release=$(tr '-' '.' <<< 1.${HOTFIX_TAG#*-})
-sed "s/__VERSION__/$version/" "$SPEC_PATH" | \
-    sed "s/__RELEASE__/$release/" > \
+sed -e "s/__VERSION__/$version/" \
+    -e "s/__RELEASE__/$release/" "$SPEC_PATH" > \
         $build_dir/osg/xrootd.spec
 
 cd $REPO_PATH

--- a/.github/workflows/hotfix-image-builds.yml
+++ b/.github/workflows/hotfix-image-builds.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   base-image-build:
     name: Build XCache base image with XRootD hot fixes
+    if: github.repository == 'opensciencegrid/docker-xcache'
     runs-on: ubuntu-latest
     outputs:
       hotfix-tag: ${{ steps.hotfix-tags.outputs.tag }}

--- a/.github/workflows/hotfix-image-builds.yml
+++ b/.github/workflows/hotfix-image-builds.yml
@@ -68,7 +68,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           path: ./docker-xcache/xcache
-          build_args: BASE_YUM_REPO=osg-upcoming-minefield
+          build_args: BASE_YUM_REPO=osg-upcoming-minefield,DEBUG=true
           tags: ${{ steps.hotfix-tags.outputs.tag }}
   xcache-image-builds:
     name: Build ${{ matrix.image }} images

--- a/.github/workflows/hotfix-image-builds.yml
+++ b/.github/workflows/hotfix-image-builds.yml
@@ -95,5 +95,19 @@ jobs:
           path: ./${{ matrix.image }}
           build_args: BASE_YUM_REPO=osg-upcoming-minefield
           tags: ${{ needs.base-image-build.outputs.hotfix-tag }}
-    # TODO: Add test jobs or steps here and sandwich them between
-    # separated image build and push. Also, push XCache base image.
+  # FIXME: Restore tests once issues with XCache 1.5.0 are addressed
+  # test-stash-cache:
+  #   name: Test Stash Cache and Origin
+  #   needs:
+  #     - base-image-build
+  #     - xcache-image-builds
+  #   # skip if no hotfix tags are found
+  #   if: needs.base-image-build.outputs.hotfix-tag != 0
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Check out docker-xcache
+  #       uses: actions/checkout@v2
+  #     - run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
+  #     - run: ./tests/test_stashcache_origin.sh "docker.pkg.github.com/$GITHUB_REPOSITORY/stash-origin:${{ needs.base-imge-build.outputs.hotfix-tag }}"
+  #     - run: ./tests/test_stashcache.sh "docker.pkg.github.com/$GITHUB_REPOSITORY/stash-cache:${{ needs.base-imge-build.outputs.hotfix-tag }}"
+

--- a/.github/workflows/hotfix-image-builds.yml
+++ b/.github/workflows/hotfix-image-builds.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   base-image-build:
-    name: Find XRootD hotfix tags and build XCache base image
+    name: Build XCache base image with XRootD hot fixes
     runs-on: ubuntu-latest
     outputs:
       hotfix-tag: ${{ steps.hotfix-tags.outputs.tag }}
@@ -37,7 +37,8 @@ jobs:
               ${{ steps.hotfix-tags.outputs.tag }} \
               ./xrootd \
               ./xrootd/packaging/rhel/xrootd.spec.in
-      - if: steps.hotfix-tags.outputs.tag != 0
+      - name: Build XRootD hotfix RPMs
+        if: steps.hotfix-tags.outputs.tag != 0
         run: |
             docker run \
               -v $(pwd)/xrootd/:/xrootd \
@@ -45,11 +46,22 @@ jobs:
               --privileged \
               opensciencegrid/osg-build:el7 \
               osg-build --verbose mock --mock-config-from-koji=osg-upcoming-el7-build _build_dir
+      - name: Move hotfix RPMs
+        if: steps.hotfix-tags.outputs.tag != 0
+        # FIXME: remove the hardcoded major version from 'xrootd' and 'xrootd-server' RPMs below
+        run: |
+            sudo mv _build_dir/_build_results/xrootd-5*.rpm \
+              _build_dir/_build_results/xrootd-debuginfo-*.rpm \
+              _build_dir/_build_results/xrootd-*libs-*.rpm \
+              _build_dir/_build_results/xrootd-selinux-*.rpm \
+              _build_dir/_build_results/xrootd-server-5*.rpm \
+              docker-xcache/xcache/packaging/
       - name: Build XCache base image
         uses: docker/build-push-action@v1
         with:
           repository: brianhlin/xcache
-          path: ./xcache
+          path: ./docker-xcache/xcache
+          build_args: BASE_YUM_REPO=osg-upcoming-minefield
           tags: ${{ needs.xrootd-rpm-build.outputs.tag }}
   xcache-image-builds:
     name: Build ${{ matrix.image }} images

--- a/.github/workflows/hotfix-image-builds.yml
+++ b/.github/workflows/hotfix-image-builds.yml
@@ -9,7 +9,7 @@ jobs:
     name: Find XRootD hotfix tags and build RPMs
     runs-on: ubuntu-latest
     outputs:
-      tags: ${{ steps.hotfix-tags.outputs.tags }}
+      hotfix-tag: ${{ steps.hotfix-tags.outputs.tag }}
     steps:
       # TODO: move this step to 'base-image-build' when our RPM
       # building actions are external to this repo
@@ -32,8 +32,8 @@ jobs:
         working-directory: ./xrootd
       - name: Checkout hotfix
         # skip if no hotfix tags are found
-        if: steps.hotfix-tags.outputs.tags != 0
-        run: git checkout ${{ steps.hotfix-tags.outputs.tags }}
+        if: steps.hotfix-tags.outputs.tag != 0
+        run: git checkout ${{ steps.hotfix-tags.outputs.tag }}
         working-directory: ./xrootd
         # TODO: Write an osg-build action that can build an RPM from an arbitrary Git repository
   #     - name: Build XRootD RPMs
@@ -47,7 +47,7 @@ jobs:
   base-image-build:
     name: Build xcache base image
     # skip if no hotfix tags are found
-    if: needs.xrootd-rpm-build.outputs.tags != 0
+    if: needs.xrootd-rpm-build.outputs.tag != 0
     needs: xrootd-rpm-build
     runs-on: ubuntu-latest
     steps:
@@ -59,38 +59,23 @@ jobs:
         with:
           repository: brianhlin/xcache
           path: ./xcache
-          push: false
-          tags: ${{ needs.xrootd-rpm-build.outputs.tags }}
-      - name: Save XCache base image
-        run: docker save --output /tmp/xcache.tar brianhlin/xcache:${{ needs.xrootd-rpm-build.outputs.tags }}
-      - name: Upload XCache base image artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: xcache-image
-          path: /tmp/xcache.tar
+          tags: ${{ needs.xrootd-rpm-build.outputs.tag }}
   xcache-image-builds:
     name: Build ${{ matrix.image }} images
     strategy:
       matrix:
         image: [atlas-xcache, cms-xcache, stash-cache, stash-origin]
     # skip if no hotfix tags are found
-    if: needs.xrootd-rpm-build.outputs.tags != 0
+    if: needs.xrootd-rpm-build.outputs.tag != 0
     needs:
-      - xrootd-rpm-build
       - base-image-build
     runs-on: ubuntu-latest
     steps:
       - name: Check out docker-xcache
         uses: actions/checkout@v2
-      - name: Download XCache base image artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: xcache-image
-      - name: Load XCache base image
-        run: docker load -i xcache.tar
       - name: Replace FROM line in Dockerfile
-        working-directory: ${{ matrix.image }}
-        run: sed -i "s|FROM opensciencegrid/xcache:fresh|FROM brianhlin/xcache:${{ needs.xrootd-rpm-build.outputs.tags }}|" Dockerfile
+        working-directory: ./docker-xcache/${{ matrix.image }}
+        run: sed -i "s|FROM opensciencegrid/xcache:fresh|FROM brianhlin/xcache:${{ needs.xrootd-rpm-build.outputs.tag }}|" Dockerfile
       - name: Build ${{ matrix.image}} image
         uses: docker/build-push-action@v1
         with:
@@ -98,6 +83,6 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           path: ./${{ matrix.image }}
-          tags: ${{ needs.xrootd-rpm-build.outputs.tags }}
+          tags: ${{ needs.xrootd-rpm-build.outputs.tag }}
     # TODO: Add test jobs or steps here and sandwich them between
     # separated image build and push. Also, push XCache base image.

--- a/.github/workflows/hotfix-image-builds.yml
+++ b/.github/workflows/hotfix-image-builds.yml
@@ -114,4 +114,28 @@ jobs:
   #     - run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
   #     - run: ./tests/test_stashcache_origin.sh "docker.pkg.github.com/$GITHUB_REPOSITORY/stash-origin:${{ needs.base-imge-build.outputs.hotfix-tag }}"
   #     - run: ./tests/test_stashcache.sh "docker.pkg.github.com/$GITHUB_REPOSITORY/stash-cache:${{ needs.base-imge-build.outputs.hotfix-tag }}"
-
+  push-images:
+    name: Push ${{ matrix.image }} image
+    strategy:
+      matrix:
+        image: [atlas-xcache, cms-xcache, stash-cache, stash-origin, xcache]
+    needs:
+      - base-image-build
+      - xcache-image-builds
+    # skip if no hotfix tags are found
+    if: needs.base-image-build.outputs.hotfix-tag != 0
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out docker-xcache
+        uses: actions/checkout@v2
+      - name: Create dummy Dockerfile
+        run: echo "FROM docker.pkg.github.com/$GITHUB_REPOSITORY/${{ matrix.image }}:${{ needs.base-image-build.outputs.hotfix-tag }}" > Dockerfile
+      - run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
+      - run: docker pull docker.pkg.github.com/$GITHUB_REPOSITORY/${{ matrix.image }}:${{ needs.base-image-build.outputs.hotfix-tag }}
+      - name: Build ${{ matrix.image}} image
+        uses: docker/build-push-action@v1
+        with:
+          repository: opensciencegrid/${{ matrix.image }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          tags: ${{ needs.base-imge-build.outputs.hotfix-tag }}

--- a/.github/workflows/hotfix-image-builds.yml
+++ b/.github/workflows/hotfix-image-builds.yml
@@ -1,3 +1,7 @@
+# TODO: detect the appropriate OSG repos and OS for build and installation
+# Currently we assume that upstream's version corresponds to what's in
+# osg-upcoming-el7-build and osg-upcoming-minefield
+
 name: Build XCache images based off of XRootD hotfix tags
 on:
   # TODO: Change to every 5 minutes once we filter out already-built tags

--- a/.github/workflows/hotfix-image-builds.yml
+++ b/.github/workflows/hotfix-image-builds.yml
@@ -65,7 +65,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           path: ./docker-xcache/xcache
           build_args: BASE_YUM_REPO=osg-upcoming-minefield
-          tags: ${{ needs.xrootd-rpm-build.outputs.tag }}
+          tags: ${{ steps.hotfix-tags.outputs.tag }}
   xcache-image-builds:
     name: Build ${{ matrix.image }} images
     strategy:

--- a/.github/workflows/hotfix-image-builds.yml
+++ b/.github/workflows/hotfix-image-builds.yml
@@ -2,7 +2,7 @@ name: Build XCache images based off of XRootD hotfix tags
 on:
   # TODO: Change to every 5 minutes once we filter out already-built tags
   schedule:
-    - cron: '17 * * * *'
+    - cron: '5 * * * *'
 
 jobs:
   xrootd-rpm-build:
@@ -23,8 +23,6 @@ jobs:
           repository: brianhlin/xrootd
           path: xrootd
           fetch-depth: 0
-      # FIXME: filter out old, already built tags (e.g. query Docker
-      # Hub for pushed tags, cache XRootD HEAD sha)
       - name: Find hotfix tags
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/hotfix-image-builds.yml
+++ b/.github/workflows/hotfix-image-builds.yml
@@ -2,7 +2,7 @@ name: Build XCache images based off of XRootD hotfix tags
 on:
   # TODO: Change to every 5 minutes once we filter out already-built tags
   schedule:
-    - cron: '5 * * * *'
+    - cron: '30 * * * *'
 
 jobs:
   xrootd-rpm-build:
@@ -30,24 +30,25 @@ jobs:
         id: hotfix-tags
         run: ../docker-xcache/.github/find-hotfix-tags.sh
         working-directory: ./xrootd
-      - name: Checkout hotfix
-        # skip if no hotfix tags are found
+      - name: Prepare hotfix sources
         if: steps.hotfix-tags.outputs.tag != 0
-        run: git checkout ${{ steps.hotfix-tags.outputs.tag }}
-        working-directory: ./xrootd
-        # TODO: Write an osg-build action that can build an RPM from an arbitrary Git repository
-  #     - name: Build XRootD RPMs
-  #       id: build-rpms
-  #       uses: ./docker-xcache/.github/actions/osg-build
-  #     - name: Upload RPM artifacts for subsequent jobs (https://github.com/actions/upload-artifact)
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: xrootd-rpms
-  #         path: path/to/artifacts/*.rpm
+        run: |
+            ./docker-xcache/.github/prep-hotfix-sources.sh \
+              ${{ steps.hotfix-tags.outputs.tag }} \
+              ./xrootd \
+              ./xrootd/packaging/rhel/xrootd.spec.in
+      - if: steps.hotfix-tags.outputs.tag != 0
+        run: |
+            docker run \
+              -v $(pwd)/xrootd/:/xrootd \
+              -v $(pwd)/_build_dir:/u/_build_dir \
+              --privileged \
+              opensciencegrid/osg-build:el7 \
+              osg-build --verbose mock --mock-config-from-koji=osg-upcoming-el7-build _build_dir
   base-image-build:
     name: Build xcache base image
     # skip if no hotfix tags are found
-    if: needs.xrootd-rpm-build.outputs.tag != 0
+    if: needs.xrootd-rpm-build.outputs.hotfix-tag != 0
     needs: xrootd-rpm-build
     runs-on: ubuntu-latest
     steps:
@@ -66,7 +67,7 @@ jobs:
       matrix:
         image: [atlas-xcache, cms-xcache, stash-cache, stash-origin]
     # skip if no hotfix tags are found
-    if: needs.xrootd-rpm-build.outputs.tag != 0
+    if: needs.xrootd-rpm-build.outputs.hotfix-tag != 0
     needs:
       - base-image-build
     runs-on: ubuntu-latest

--- a/.github/workflows/hotfix-image-builds.yml
+++ b/.github/workflows/hotfix-image-builds.yml
@@ -59,7 +59,10 @@ jobs:
       - name: Build XCache base image
         uses: docker/build-push-action@v1
         with:
-          repository: brianhlin/xcache
+          repository: ${{ github.repository }}/xcache
+          registry: docker.pkg.github.com
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
           path: ./docker-xcache/xcache
           build_args: BASE_YUM_REPO=osg-upcoming-minefield
           tags: ${{ needs.xrootd-rpm-build.outputs.tag }}
@@ -77,15 +80,20 @@ jobs:
       - name: Check out docker-xcache
         uses: actions/checkout@v2
       - name: Replace FROM line in Dockerfile
-        working-directory: ./docker-xcache/${{ matrix.image }}
-        run: sed -i "s|FROM opensciencegrid/xcache:fresh|FROM brianhlin/xcache:${{ needs.xrootd-rpm-build.outputs.tag }}|" Dockerfile
+        working-directory: ${{ matrix.image }}
+        run: |
+            sed -i \
+              "s|FROM opensciencegrid/xcache:fresh|FROM docker.pkg.github.com/$GITHUB_REPOSITORY/xcache:${{ needs.base-image-build.outputs.hotfix-tag }}|" \
+              Dockerfile
       - name: Build ${{ matrix.image}} image
         uses: docker/build-push-action@v1
         with:
-          repository: brianhlin/${{ matrix.image }}
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: ${{ github.repository }}/${{ matrix.image }}
+          registry: docker.pkg.github.com
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
           path: ./${{ matrix.image }}
-          tags: ${{ needs.xrootd-rpm-build.outputs.tag }}
+          build_args: BASE_YUM_REPO=osg-upcoming-minefield
+          tags: ${{ needs.base-image-build.outputs.hotfix-tag }}
     # TODO: Add test jobs or steps here and sandwich them between
     # separated image build and push. Also, push XCache base image.

--- a/.github/workflows/hotfix-image-builds.yml
+++ b/.github/workflows/hotfix-image-builds.yml
@@ -1,0 +1,102 @@
+name: Build XCache images based off of XRootD hotfix tags
+on:
+  # TODO: Change to every 5 minutes once we filter out already-built tags
+  schedule:
+    - cron: '17 * * * *'
+
+jobs:
+  xrootd-rpm-build:
+    name: Find XRootD hotfix tags and build RPMs
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.hotfix-tags.outputs.tags }}
+    steps:
+      # TODO: move this step to 'base-image-build' when our RPM
+      # building actions are external to this repo
+      - name: Check out docker-xcache
+        uses: actions/checkout@v2
+        with:
+          path: docker-xcache
+      - name: Check out XRootD
+        uses: actions/checkout@v2
+        with:
+          repository: brianhlin/xrootd
+          path: xrootd
+          fetch-depth: 0
+      # FIXME: filter out old, already built tags (e.g. query Docker
+      # Hub for pushed tags, cache XRootD HEAD sha)
+      - name: Find hotfix tags
+        id: hotfix-tags
+        run: echo "::set-output name=tags::$(git tag -l | egrep 'v[0-9]+\.[0-9]+\.[0-9]+-hotfix-[A-Za-z]+')"
+        working-directory: ./xrootd
+      - name: Checkout hotfix
+        # skip if no hotfix tags are found
+        if: steps.hotfix-tags.outputs.tags != 0
+        run: git checkout ${{ steps.hotfix-tags.outputs.tags }}
+        working-directory: ./xrootd
+        # TODO: Write an osg-build action that can build an RPM from an arbitrary Git repository
+  #     - name: Build XRootD RPMs
+  #       id: build-rpms
+  #       uses: ./docker-xcache/.github/actions/osg-build
+  #     - name: Upload RPM artifacts for subsequent jobs (https://github.com/actions/upload-artifact)
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: xrootd-rpms
+  #         path: path/to/artifacts/*.rpm
+  base-image-build:
+    name: Build xcache base image
+    # skip if no hotfix tags are found
+    if: needs.xrootd-rpm-build.outputs.tags != 0
+    needs: xrootd-rpm-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out docker-xcache
+        uses: actions/checkout@v2
+      # TODO: Modify the Dockerfile so that it can build from local RPMs
+      - name: Build XCache base image
+        uses: docker/build-push-action@v1
+        with:
+          repository: brianhlin/xcache
+          path: ./xcache
+          push: false
+          tags: ${{ needs.xrootd-rpm-build.outputs.tags }}
+      - name: Save XCache base image
+        run: docker save --output /tmp/xcache.tar brianhlin/xcache:${{ needs.xrootd-rpm-build.outputs.tags }}
+      - name: Upload XCache base image artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: xcache-image
+          path: /tmp/xcache.tar
+  xcache-image-builds:
+    name: Build ${{ matrix.image }} images
+    strategy:
+      matrix:
+        image: [atlas-xcache, cms-xcache, stash-cache, stash-origin]
+    # skip if no hotfix tags are found
+    if: needs.xrootd-rpm-build.outputs.tags != 0
+    needs:
+      - xrootd-rpm-build
+      - base-image-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out docker-xcache
+        uses: actions/checkout@v2
+      - name: Download XCache base image artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: xcache-image
+      - name: Load XCache base image
+        run: docker load -i xcache.tar
+      - name: Replace FROM line in Dockerfile
+        working-directory: ${{ matrix.image }}
+        run: sed -i "s|FROM opensciencegrid/xcache:fresh|FROM brianhlin/xcache:${{ needs.xrootd-rpm-build.outputs.tags }}|" Dockerfile
+      - name: Build ${{ matrix.image}} image
+        uses: docker/build-push-action@v1
+        with:
+          repository: brianhlin/${{ matrix.image }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          path: ./${{ matrix.image }}
+          tags: ${{ needs.xrootd-rpm-build.outputs.tags }}
+    # TODO: Add test jobs or steps here and sandwich them between
+    # separated image build and push. Also, push XCache base image.

--- a/.github/workflows/hotfix-image-builds.yml
+++ b/.github/workflows/hotfix-image-builds.yml
@@ -26,8 +26,11 @@ jobs:
       # FIXME: filter out old, already built tags (e.g. query Docker
       # Hub for pushed tags, cache XRootD HEAD sha)
       - name: Find hotfix tags
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         id: hotfix-tags
-        run: echo "::set-output name=tags::$(git tag -l | egrep 'v[0-9]+\.[0-9]+\.[0-9]+-hotfix-[A-Za-z]+')"
+        run: ../docker-xcache/.github/find-hotfix-tags.sh
         working-directory: ./xrootd
       - name: Checkout hotfix
         # skip if no hotfix tags are found

--- a/.github/workflows/hotfix-image-builds.yml
+++ b/.github/workflows/hotfix-image-builds.yml
@@ -4,9 +4,9 @@
 
 name: Build XCache images based off of XRootD hotfix tags
 on:
-  # TODO: Change to every 5 minutes once we filter out already-built tags
   schedule:
-    - cron: '30 * * * *'
+    # Builds take ~15-25 min
+    - cron: '*/30 * * * *'
 
 jobs:
   base-image-build:
@@ -24,7 +24,7 @@ jobs:
       - name: Check out XRootD
         uses: actions/checkout@v2
         with:
-          repository: brianhlin/xrootd
+          repository: xrootd/xrootd
           path: xrootd
           fetch-depth: 0
       - name: Find hotfix tags

--- a/.github/workflows/hotfix-image-builds.yml
+++ b/.github/workflows/hotfix-image-builds.yml
@@ -5,8 +5,8 @@ on:
     - cron: '30 * * * *'
 
 jobs:
-  xrootd-rpm-build:
-    name: Find XRootD hotfix tags and build RPMs
+  base-image-build:
+    name: Find XRootD hotfix tags and build XCache base image
     runs-on: ubuntu-latest
     outputs:
       hotfix-tag: ${{ steps.hotfix-tags.outputs.tag }}
@@ -45,16 +45,6 @@ jobs:
               --privileged \
               opensciencegrid/osg-build:el7 \
               osg-build --verbose mock --mock-config-from-koji=osg-upcoming-el7-build _build_dir
-  base-image-build:
-    name: Build xcache base image
-    # skip if no hotfix tags are found
-    if: needs.xrootd-rpm-build.outputs.hotfix-tag != 0
-    needs: xrootd-rpm-build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out docker-xcache
-        uses: actions/checkout@v2
-      # TODO: Modify the Dockerfile so that it can build from local RPMs
       - name: Build XCache base image
         uses: docker/build-push-action@v1
         with:
@@ -66,10 +56,10 @@ jobs:
     strategy:
       matrix:
         image: [atlas-xcache, cms-xcache, stash-cache, stash-origin]
-    # skip if no hotfix tags are found
-    if: needs.xrootd-rpm-build.outputs.hotfix-tag != 0
     needs:
       - base-image-build
+    # skip if no hotfix tags are found
+    if: needs.base-image-build.outputs.hotfix-tag != 0
     runs-on: ubuntu-latest
     steps:
       - name: Check out docker-xcache

--- a/xcache/Dockerfile
+++ b/xcache/Dockerfile
@@ -12,6 +12,15 @@ ENV XC_ROOTDIR /xcache/namespace
 RUN groupadd -o -g 10940 xrootd
 RUN useradd -o -u 10940 -g 10940 -s /bin/sh xrootd
 
+RUN mkdir -p /var/lib/xcache/
+# ADD complains when there aren't files that match a wildcard so we
+# this needs to be relatively unrestricted to support the case where
+# there aren't any pre-built RPMs
+ADD packaging/* /var/lib/xcache/
+
+# Install any pre-built RPMs
+RUN yum -y install /var/lib/xcache/*.rpm --enablerepo="$BASE_YUM_REPO" || \
+    true
 RUN yum install -y --enablerepo="$BASE_YUM_REPO" \
         xcache \
         gperftools-devel && \

--- a/xcache/Dockerfile
+++ b/xcache/Dockerfile
@@ -43,9 +43,6 @@ ADD xrootd/* /etc/xrootd/config.d/
 RUN mkdir -p "$XC_ROOTDIR"
 RUN chown -R xrootd:xrootd /xcache/
 
-# Remove the core file soft limit
-RUN [[ -z "$DEBUG" ]] || ulimit -S -c unlimited
-
 # Avoid 'Unable to create home directory' messages
 # in the XRootD logs
 WORKDIR /var/spool/xrootd

--- a/xcache/Dockerfile
+++ b/xcache/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer OSG Software <help@opensciencegrid.org>
 
 # Specify the base Yum repository to get the necessary RPMs
 ARG BASE_YUM_REPO
+ARG DEBUG
 
 # Default root dir
 ENV XC_ROOTDIR /xcache/namespace
@@ -21,6 +22,13 @@ ADD packaging/* /var/lib/xcache/
 # Install any pre-built RPMs
 RUN yum -y install /var/lib/xcache/*.rpm --enablerepo="$BASE_YUM_REPO" || \
     true
+
+# Install debugging tools if DEBUG set
+RUN [[ -z "$DEBUG" ]] || \
+    yum -y install -y --enablerepo="$BASE_YUM_REPO" \
+    gdb \
+    strace
+
 RUN yum install -y --enablerepo="$BASE_YUM_REPO" \
         xcache \
         gperftools-devel && \
@@ -34,6 +42,9 @@ ADD xrootd/* /etc/xrootd/config.d/
 
 RUN mkdir -p "$XC_ROOTDIR"
 RUN chown -R xrootd:xrootd /xcache/
+
+# Remove the core file soft limit
+RUN [[ -z "$DEBUG" ]] || ulimit -S -c unlimited
 
 # Avoid 'Unable to create home directory' messages
 # in the XRootD logs

--- a/xcache/image-config.d/10-debug.sh
+++ b/xcache/image-config.d/10-debug.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+# Remove the core file soft limit
 [[ -z "$DEBUG" ]] || ulimit -S -c unlimited

--- a/xcache/image-config.d/10-debug.sh
+++ b/xcache/image-config.d/10-debug.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+[[ -z "$DEBUG" ]] || ulimit -S -c unlimited

--- a/xcache/packaging/README.md
+++ b/xcache/packaging/README.md
@@ -1,0 +1,2 @@
+Place pre-built binary RPMs in this dir to install them into the XCache container
+


### PR DESCRIPTION
https://opensciencegrid.atlassian.net/browse/SOFTWARE-4151

This PR adds XCache hotfix image builds that:

1. Detect https://github.com/xrootd/xrootd/ hotfix tags (`vX.Y.Z-osghotfix-A`)
1. Build RPMs under the OSG build environment
1. Builds an XCache base image based on these RPMs along with debugging tools, pushing it to the GitHub registry
1. Builds atlas-xcache, cms-xcache, stash-cache, and stash-origin tests images, pushing them to the GitHub registry
1. Skips tests because they're currently broken
1. Pushes all of the created images to Docker Hub with the hotfix tag