### PR TITLE
Only push images from the OSG repo

### DIFF
--- a/.github/workflows/release-image-builds.yml
+++ b/.github/workflows/release-image-builds.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   get-timestamp:
     name: Get timestamp for tagging images
+    if: github.repository == 'opensciencegrid/docker-xcache'
     runs-on: ubuntu-latest
     outputs:
       dtag: ${{ steps.timestamp-tag.outputs.dtag }}
@@ -83,7 +84,7 @@ jobs:
       - run: ./tests/test_stashcache.sh "docker.pkg.github.com/$GITHUB_REPOSITORY/stash-cache:${{ matrix.yum_repo_prefix }}minefield-${{ needs.get-timestamp.outputs.dtag }}"
   push-images:
     name: Push ${{ matrix.image }}:${{ matrix.yum_repo_prefix }}fresh image
-    if: github.repository == 'opensciencegrid/docker-xcache' && github.event_name == 'push'
+    if: github.event_name == 'push'
     strategy:
       matrix:
         image: [atlas-xcache, cms-xcache, stash-cache, stash-origin, xcache]

--- a/.github/workflows/release-image-builds.yml
+++ b/.github/workflows/release-image-builds.yml
@@ -84,7 +84,6 @@ jobs:
       - run: ./tests/test_stashcache.sh "docker.pkg.github.com/$GITHUB_REPOSITORY/stash-cache:${{ matrix.yum_repo_prefix }}minefield-${{ needs.get-timestamp.outputs.dtag }}"
   push-images:
     name: Push ${{ matrix.image }}:${{ matrix.yum_repo_prefix }}fresh image
-    if: github.event_name == 'push'
     strategy:
       matrix:
         image: [atlas-xcache, cms-xcache, stash-cache, stash-origin, xcache]

--- a/.github/workflows/release-image-builds.yml
+++ b/.github/workflows/release-image-builds.yml
@@ -83,7 +83,7 @@ jobs:
       - run: ./tests/test_stashcache.sh "docker.pkg.github.com/$GITHUB_REPOSITORY/stash-cache:${{ matrix.yum_repo_prefix }}minefield-${{ needs.get-timestamp.outputs.dtag }}"
   push-images:
     name: Push ${{ matrix.image }}:${{ matrix.yum_repo_prefix }}fresh image
-    if: github.event_name == 'push'
+    if: github.repository == 'opensciencegrid/docker-xcache' && github.event_name == 'push'
     strategy:
       matrix:
         image: [atlas-xcache, cms-xcache, stash-cache, stash-origin, xcache]


### PR DESCRIPTION
As requested by Mat:

- https://github.com/opensciencegrid/docker-software-base/pull/16
- https://github.com/opensciencegrid/docker-frontier-squid/pull/12

We should see the set of push jobs skipped in my own actions: https://github.com/brianhlin/docker-xcache/actions/runs/206176733