### PR TITLE
Multi-disk origins don't make much sense (SOFTWARE-4159)

### DIFF
--- a/xcache/xrootd/50-docker-paths.cfg
+++ b/xcache/xrootd/50-docker-paths.cfg
@@ -5,7 +5,6 @@ else if named stash-origin-auth
   # do nothing
 else
   pfc.spaces data meta
+  oss.space meta /xcache/meta*
+  oss.space data /xcache/data*
 fi
-
-oss.space meta /xcache/meta*
-oss.space data /xcache/data*


### PR DESCRIPTION
Tell origin users to mount their partition to `/xcache/namespace/`