### PR TITLE
Ability to change the log limit via env variable

### DIFF
--- a/atlas-xcache/supervisord.d/10-atlas-xcache.conf
+++ b/atlas-xcache/supervisord.d/10-atlas-xcache.conf
@@ -1,5 +1,5 @@
 [program:atlas-xcache]
-command=xrootd -c /etc/xrootd/xrootd-atlas-xcache.cfg -k fifo -n atlas-xcache -k 10 -s /var/run/xrootd/xrootd-atlas-xcache.pid -l /var/log/xrootd/xrootd.log
+command=xrootd -c /etc/xrootd/xrootd-atlas-xcache.cfg -k fifo -n atlas-xcache -k 10 -s /var/run/xrootd/xrootd-atlas-xcache.pid -l /var/log/xrootd/xrootd.log -k %(ENV_XC_NUM_LOGROTATE)s
 user=xrootd
 autorestart=true
 environment=LD_PRELOAD=/usr/lib64/libtcmalloc.so,TCMALLOC_RELEASE_RATE=10

--- a/cms-xcache/supervisord.d/10-cms-xcache.conf
+++ b/cms-xcache/supervisord.d/10-cms-xcache.conf
@@ -1,5 +1,5 @@
 [program:cms-xcache]
-command=xrootd -c /etc/xrootd/xrootd-cms-xcache.cfg -k fifo -n cms-xcache -k 10 -s /var/run/xrootd/xrootd-cms-xcache.pid -l /var/log/xrootd/xrootd.log
+command=xrootd -c /etc/xrootd/xrootd-cms-xcache.cfg -k fifo -n cms-xcache -k 10 -s /var/run/xrootd/xrootd-cms-xcache.pid -l /var/log/xrootd/xrootd.log -k %(ENV_XC_NUM_LOGROTATE)s
 user=xrootd
 autorestart=true
 environment=LD_PRELOAD=/usr/lib64/libtcmalloc.so,TCMALLOC_RELEASE_RATE=10

--- a/stash-cache/supervisord.d/10-stash-cache.conf
+++ b/stash-cache/supervisord.d/10-stash-cache.conf
@@ -4,13 +4,13 @@ user=xrootd
 priority=998
 
 [program:stash-cache]
-command=xrootd -c /etc/xrootd/xrootd-stash-cache.cfg -k fifo -n stash-cache -k 10 -s /var/run/xrootd/xrootd-stash-cache.pid -l /var/log/xrootd/xrootd.log
+command=xrootd -c /etc/xrootd/xrootd-stash-cache.cfg -k fifo -n stash-cache -k 10 -s /var/run/xrootd/xrootd-stash-cache.pid -l /var/log/xrootd/xrootd.log -k %(ENV_XC_NUM_LOGROTATE)s
 user=xrootd
 autorestart=true
 environment=LD_PRELOAD=/usr/lib64/libtcmalloc.so,TCMALLOC_RELEASE_RATE=10
 
 [program:stash-cache-auth]
-command=xrootd -c /etc/xrootd/xrootd-stash-cache-auth.cfg -k fifo -n stash-cache-auth -k 10 -s /var/run/xrootd/xrootd-stash-cache-auth.pid -l /var/log/xrootd/xrootd.log
+command=xrootd -c /etc/xrootd/xrootd-stash-cache-auth.cfg -k fifo -n stash-cache-auth -k 10 -s /var/run/xrootd/xrootd-stash-cache-auth.pid -l /var/log/xrootd/xrootd.log -k %(ENV_XC_NUM_LOGROTATE)s
 user=xrootd
 autorestart=true
 environment=LD_PRELOAD=/usr/lib64/libtcmalloc.so,TCMALLOC_RELEASE_RATE=10

--- a/stash-origin/supervisord.d/stash-origin-auth.conf
+++ b/stash-origin/supervisord.d/stash-origin-auth.conf
@@ -4,7 +4,7 @@ user=xrootd
 priority=998
 
 [program:stash-origin-auth]
-command=xrootd -c /etc/xrootd/xrootd-stash-origin-auth.cfg -k fifo -n stash-origin-auth -k 10 -s /var/run/xrootd/xrootd-stash-origin-auth.pid -l /var/log/xrootd/xrootd.log
+command=xrootd -c /etc/xrootd/xrootd-stash-origin-auth.cfg -k fifo -n stash-origin-auth -k 10 -s /var/run/xrootd/xrootd-stash-origin-auth.pid -l /var/log/xrootd/xrootd.log -k %(ENV_XC_NUM_LOGROTATE)s
 user=xrootd
 directory=/var/spool/xrootd
 autorestart=true

--- a/stash-origin/supervisord.d/stash-origin.conf
+++ b/stash-origin/supervisord.d/stash-origin.conf
@@ -1,5 +1,5 @@
 [program:stash-origin]
-command=xrootd -c /etc/xrootd/xrootd-stash-origin.cfg -k fifo -n stash-origin -k 10 -s /var/run/xrootd/xrootd-origin-origin.pid -l /var/log/xrootd/xrootd.log
+command=xrootd -c /etc/xrootd/xrootd-stash-origin.cfg -k fifo -n stash-origin -k 10 -s /var/run/xrootd/xrootd-origin-origin.pid -l /var/log/xrootd/xrootd.log -k %(ENV_XC_NUM_LOGROTATE)s
 user=xrootd
 directory=/var/spool/xrootd
 autorestart=true

--- a/xcache/Dockerfile
+++ b/xcache/Dockerfile
@@ -9,6 +9,9 @@ ARG DEBUG
 # Default root dir
 ENV XC_ROOTDIR /xcache/namespace
 
+# Default logrotate XRootd logs
+ENV XC_NUM_LOGROTATE 7
+
 # Create the xrootd user with a fixed GID/UID
 RUN groupadd -o -g 10940 xrootd
 RUN useradd -o -u 10940 -g 10940 -s /bin/sh xrootd


### PR DESCRIPTION
This is long overdue. Our friends at ESNet asked us to keep more than the default seven logrotates for XRootD. So I might as well enabled it for everybody than just for CMS.