### PR TITLE
GitHub Action fixups

### DIFF
--- a/.github/find-hotfix-tags.sh
+++ b/.github/find-hotfix-tags.sh
@@ -34,4 +34,5 @@ curl -s \
 # cowardly only build one hotfix tag at a time
 build_candidate=$(comm -23 git_tags dockerhub_tags | head -n 1)
 
+echo "Found hotfix tag: $build_candidatuild_candidatee"
 echo "::set-output name=tag::$build_candidate"

--- a/.github/prep-hotfix-sources.sh
+++ b/.github/prep-hotfix-sources.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash -xe
 
 HOTFIX_TAG=$1
 REPO_PATH=$2

--- a/.github/prep-hotfix-sources.sh
+++ b/.github/prep-hotfix-sources.sh
@@ -6,9 +6,7 @@ SPEC_PATH=$3
 
 # Create OSG build dirs
 build_dir=$PWD/_build_dir
-for subdir in osg upstream; do
-    mkdir -p "$build_dir/$subdir"
-done
+mkdir -p "$build_dir"/{osg,upstream}
 
 [[ $HOTFIX_TAG =~ ^(v[0-9]+\.[0-9]+\.[0-9]+)-(.*) ]]
 version=${BASH_REMATCH[1]}

--- a/.github/prep-hotfix-sources.sh
+++ b/.github/prep-hotfix-sources.sh
@@ -6,7 +6,9 @@ SPEC_PATH=$3
 
 # Create OSG build dirs
 build_dir=$PWD/_build_dir
-mkdir -p "$build_dir/{osg,upstream}"
+for subdir in osg upstream; do
+    mkdir -p "$build_dir/$subdir"
+done
 
 [[ $HOTFIX_TAG =~ ^(v[0-9]+\.[0-9]+\.[0-9]+)-(.*) ]]
 version=${BASH_REMATCH[1]}


### PR DESCRIPTION
There are strange issues with missing "No such file or directory":

- https://github.com/opensciencegrid/docker-xcache/runs/1124795837?check_suite_focus=true#step:6:16
- https://github.com/opensciencegrid/docker-xcache/runs/1124795837?check_suite_focus=true#step:6:42

Since the files referenced are being created by the failing pipelines, it looks like the parent dirs aren't being created. The dirs should be created here so it's not clear why they aren't:

https://github.com/opensciencegrid/docker-xcache/runs/1124795837?check_suite_focus=true#step:6:11

My only guess was an issue with brace expansion.