### PR TITLE
Bail out via return instead of exit

### DIFF
--- a/xcache/image-config.d/10-single-host-disk.sh
+++ b/xcache/image-config.d/10-single-host-disk.sh
@@ -3,7 +3,7 @@
 # If the user is not using the prescribed location, don't separate out
 # the namespace, metadata, or data dirs since that may clear the cache
 if [[ "$XC_ROOTDIR" != /xcache/namespace ]]; then
-    exit
+    return
 fi
 
 # If the user is mounting a single disk onto /xcache, create oss.localroot for them


### PR DESCRIPTION
exit stops loading the rest of the image-config.d scripts