### PR TITLE
Allow development containers to fail tests

### DIFF
--- a/.github/workflows/release-image-builds.yml
+++ b/.github/workflows/release-image-builds.yml
@@ -82,6 +82,7 @@ jobs:
     name: Test Stash Cache and Origin
     needs: [xcache-image-builds]
     runs-on: ubuntu-latest
+    continue-on-error: matrix.repo == 'development'
     strategy:
       fail-fast: False
       matrix:


### PR DESCRIPTION
We still allow the image to be pushed to Docker Hub since

1.  We don't make any promises for the development Yum repos
2.  These images may be useful for internal debugging