### PR TITLE
Run xcache as user instead of root

### DIFF
--- a/atlas-xcache/image-config.d/10-atlas-xcache.sh
+++ b/atlas-xcache/image-config.d/10-atlas-xcache.sh
@@ -2,5 +2,5 @@
 
 /usr/local/sbin/fix_certs.sh
 
-su xrootd /usr/libexec/xcache/renew-proxy --voms atlas
+/usr/libexec/xcache/renew-proxy --voms atlas
 

--- a/atlas-xcache/supervisord.d/10-atlas-xcache.conf
+++ b/atlas-xcache/supervisord.d/10-atlas-xcache.conf
@@ -1,5 +1,4 @@
 [program:atlas-xcache]
 command=xrootd -c /etc/xrootd/xrootd-atlas-xcache.cfg -k fifo -n atlas-xcache -k %(ENV_XC_NUM_LOGROTATE)s -s /var/run/xrootd/xrootd-atlas-xcache.pid -l /var/log/xrootd/xrootd.log
-user=xrootd
 autorestart=true
 environment=LD_PRELOAD=/usr/lib64/libtcmalloc.so,TCMALLOC_RELEASE_RATE=10

--- a/cms-xcache/image-config.d/20-cms-generate-proxy.sh
+++ b/cms-xcache/image-config.d/20-cms-generate-proxy.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 /usr/local/sbin/fix_certs.sh
-su xrootd -c '/usr/libexec/xcache/renew-proxy --voms cms'
+/usr/libexec/xcache/renew-proxy --voms cms

--- a/cms-xcache/supervisord.d/10-cms-xcache.conf
+++ b/cms-xcache/supervisord.d/10-cms-xcache.conf
@@ -1,6 +1,5 @@
 [program:cms-xcache]
 command=xrootd -c /etc/xrootd/xrootd-cms-xcache.cfg -k fifo -n cms-xcache -k %(ENV_XC_NUM_LOGROTATE)s -s /var/run/xrootd/xrootd-cms-xcache.pid -l /var/log/xrootd/xrootd.log
-user=xrootd
 autorestart=true
 environment=LD_PRELOAD=/usr/lib64/libtcmalloc.so,TCMALLOC_RELEASE_RATE=10
 

--- a/stash-cache/image-config.d/20-generate-proxy.sh
+++ b/stash-cache/image-config.d/20-generate-proxy.sh
@@ -2,4 +2,4 @@
 
 # Generate the proxy
 /usr/local/sbin/fix_certs.sh
-su xrootd /usr/libexec/xcache/renew-proxy
+/usr/libexec/xcache/renew-proxy

--- a/stash-cache/image-config.d/40-generate-auth-file.sh
+++ b/stash-cache/image-config.d/40-generate-auth-file.sh
@@ -3,10 +3,6 @@
 # Generate the Auth File
 /usr/libexec/xcache/authfile-update --cache
 shopt -s nullglob
-for f in /run/stash-cache/* /run/stash-cache-auth/*; do
-    chown xrootd:xrootd "$f"
-done
-shopt -u nullglob
 
 # ddavila 20211020: Save the env vars CACHE_FQDN to be used
 # later by 'xrootd' on the 'authfile-update' script.
@@ -16,4 +12,3 @@ if [[ -n ${CACHE_FQDN} ]]; then
         echo "export CACHE_FQDN=${CACHE_FQDN}" >> /etc/xrootd-environment
 fi
 
-chown xrootd:xrootd /etc/xrootd-environment

--- a/stash-cache/supervisord.d/10-stash-cache.conf
+++ b/stash-cache/supervisord.d/10-stash-cache.conf
@@ -1,16 +1,13 @@
 [program:stash-cache-authfile-update]
 command=/usr/libexec/xcache/authfile-update --cache
-user=xrootd
 priority=998
 
 [program:stash-cache]
 command=xrootd -c /etc/xrootd/xrootd-stash-cache.cfg -k fifo -n stash-cache -k %(ENV_XC_NUM_LOGROTATE)s -s /var/run/xrootd/xrootd-stash-cache.pid -l /var/log/xrootd/xrootd.log
-user=xrootd
 autorestart=true
 environment=LD_PRELOAD=/usr/lib64/libtcmalloc.so,TCMALLOC_RELEASE_RATE=10
 
 [program:stash-cache-auth]
 command=xrootd -c /etc/xrootd/xrootd-stash-cache-auth.cfg -k fifo -n stash-cache-auth -k %(ENV_XC_NUM_LOGROTATE)s -s /var/run/xrootd/xrootd-stash-cache-auth.pid -l /var/log/xrootd/xrootd.log
-user=xrootd
 autorestart=true
 environment=LD_PRELOAD=/usr/lib64/libtcmalloc.so,TCMALLOC_RELEASE_RATE=10

--- a/stash-origin/image-config.d/40-generate-auth-file.sh
+++ b/stash-origin/image-config.d/40-generate-auth-file.sh
@@ -3,10 +3,6 @@
 # Generate the Auth File
 /usr/libexec/xcache/authfile-update --origin
 shopt -s nullglob
-for f in /run/stash-origin/* /run/stash-origin-auth/*; do
-    chown xrootd:xrootd "$f"
-done
-shopt -u nullglob
 
 # ddavila 20220225: Save the env var ORIGIN_FQDN to be used
 # later by 'xrootd' on the 'authfile-update' script.
@@ -15,4 +11,3 @@ echo "# This file was generated on startup" > /etc/xrootd-environment
 if [[ -n ${ORIGIN_FQDN} ]]; then
         echo "export ORIGIN_FQDN=${ORIGIN_FQDN}" >> /etc/xrootd-environment
 fi
-chown xrootd:xrootd /etc/xrootd-environment

--- a/stash-origin/supervisord.d/stash-origin-cmsd.conf
+++ b/stash-origin/supervisord.d/stash-origin-cmsd.conf
@@ -1,6 +1,5 @@
 [program:stash-origin-cmsd]
 command=/usr/bin/cmsd -l /var/log/xrootd/cmsd.log -c /etc/xrootd/xrootd-stash-origin.cfg -k fifo -s /var/run/xrootd/cmsd-stash-origin.pid -n stash-origin
-user=xrootd
 directory=/var/spool/xrootd
 autorestart=true
 environment=LD_PRELOAD=/usr/lib64/libtcmalloc.so,TCMALLOC_RELEASE_RATE=10

--- a/stash-origin/supervisord.d/stash-origin.conf
+++ b/stash-origin/supervisord.d/stash-origin.conf
@@ -1,6 +1,5 @@
 [program:stash-origin]
 command=xrootd -c /etc/xrootd/xrootd-stash-origin.cfg -k fifo -n stash-origin -k %(ENV_XC_NUM_LOGROTATE)s -s /var/run/xrootd/xrootd-origin-origin.pid -l /var/log/xrootd/xrootd.log
-user=xrootd
 directory=/var/spool/xrootd
 autorestart=true
 environment=LD_PRELOAD=/usr/lib64/libtcmalloc.so,TCMALLOC_RELEASE_RATE=10

--- a/xcache/sbin/fix_certs.sh
+++ b/xcache/sbin/fix_certs.sh
@@ -8,7 +8,6 @@ tmpkey=`mktemp`
 
 chmod 644 $tmpcert
 chmod 600 $tmpkey
-chown xrootd:xrootd $tmpcert $tmpkey
 
 cp $grid_security/hostcert.pem $tmpcert
 cp $grid_security/hostkey.pem $tmpkey


### PR DESCRIPTION
Even in containers, it's best practice to execute code as a user rather than as root whenever possible.  In addition,
some multi-tenant Kubernetes systems (Red Hat OpenShift / OKD) have a default security policy that executes
containers with an ephemeral UID with GID 0.  This change (along with substituting go-crond for crond in the base
software image) should enable running as any user with GID 0.