### PR TITLE
Move the supervisord config for the auth cache instance to a separate file

### DIFF
--- a/stash-cache/supervisord.d/10-stash-cache.conf
+++ b/stash-cache/supervisord.d/10-stash-cache.conf
@@ -8,9 +8,3 @@ command=xrootd -c /etc/xrootd/xrootd-stash-cache.cfg -k fifo -n stash-cache -k %
 user=xrootd
 autorestart=true
 environment=LD_PRELOAD=/usr/lib64/libtcmalloc.so,TCMALLOC_RELEASE_RATE=10
-
-[program:stash-cache-auth]
-command=xrootd -c /etc/xrootd/xrootd-stash-cache-auth.cfg -k fifo -n stash-cache-auth -k %(ENV_XC_NUM_LOGROTATE)s -s /var/run/xrootd/xrootd-stash-cache-auth.pid -l /var/log/xrootd/xrootd.log
-user=xrootd
-autorestart=true
-environment=LD_PRELOAD=/usr/lib64/libtcmalloc.so,TCMALLOC_RELEASE_RATE=10

--- a/stash-cache/supervisord.d/11-stash-cache-auth.conf
+++ b/stash-cache/supervisord.d/11-stash-cache-auth.conf
@@ -1,0 +1,5 @@
+[program:stash-cache-auth]
+command=xrootd -c /etc/xrootd/xrootd-stash-cache-auth.cfg -k fifo -n stash-cache-auth -k %(ENV_XC_NUM_LOGROTATE)s -s /var/run/xrootd/xrootd-stash-cache-auth.pid -l /var/log/xrootd/xrootd.log
+user=xrootd
+autorestart=true
+environment=LD_PRELOAD=/usr/lib64/libtcmalloc.so,TCMALLOC_RELEASE_RATE=10


### PR DESCRIPTION
This will allow you to disable the auth instance by bind-mounting an empty file over `/etc/supervisord.d/11-stash-cache-auth.conf`