### PR TITLE
Support setting PublicAuthOriginExport and AuthOriginExport for the stash-origin

### DIFF
--- a/stash-origin/xrootd/10-origin-docker-env-var.cfg
+++ b/stash-origin/xrootd/10-origin-docker-env-var.cfg
@@ -1,9 +1,35 @@
-# Allow users to specify their originexport relative to XC_ROOTDIR
+# Allow users to specify their exports relative to XC_ROOTDIR
 # (/mnt/stash by default).
 
-# If XC_ORIGINEXPORT is not specified, the Stash Origin will serve _all_
-# its data out of XC_ROOTDIR, so that is where you should mount the host
-# partition containing the origin data
+# Set XC_PUBLIC_ORIGIN_EXPORT to the subdirectory that the
+# unauthenticated instance (port 1094, if enabled) will serve.
+
+# Set XC_AUTH_ORIGIN_EXPORT to the subdirectory that the
+# authenticated instance (port 1095, if enabled) will serve.
+
+# If you are running a version of the container without
+# https://opensciencegrid.atlassian.net/browse/SOFTWARE-5303,
+# set XC_ORIGINEXPORT to the subdirectory that either instance
+# of the origin will serve.
+
+# If none of those variables are specified, the Stash Origin
+# will serve _all_ its data out of XC_ROOTDIR, so that is
+# where you should mount the host partition containing the
+# origin data.
+
+# WARNING: You must specify *both* XC_PUBLIC_ORIGIN_EXPORT
+# and XC_AUTH_ORIGIN_EXPORT to run both a public and an auth
+# origin on the same host.
+
+if defined ?~XC_PUBLIC_ORIGIN_EXPORT
+  set PublicOriginExport=$XC_PUBLIC_ORIGIN_EXPORT
+fi
+
+if defined ?~XC_AUTH_ORIGIN_EXPORT
+  set AuthOriginExport=$XC_AUTH_ORIGIN_EXPORT
+fi
+
+### backward compat: only used if the others aren't defined
 if defined ?~XC_ORIGINEXPORT
 set originexport=$XC_ORIGINEXPORT
 else


### PR DESCRIPTION
[SOFTWARE-5303](https://opensciencegrid.atlassian.net/browse/SOFTWARE-5303). Makes use of the functionality added in https://github.com/opensciencegrid/xcache/pull/133.