### PR TITLE
Add syslog support to the XCache container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,9 @@ RUN chmod 0644 /etc/cron.d/*
 ADD xcache/sbin/* /usr/local/sbin/
 ADD xcache/image-config.d/* /etc/osg/image-init.d/
 ADD xcache/xrootd/* /etc/xrootd/config.d/
+ADD xcache/rsyslog.conf /etc/rsyslog.conf
+
+RUN rm -f /etc/rsyslog.d/listen.conf
 
 RUN mkdir -p "$XC_ROOTDIR" /var/spool/rsyslog/workdir /var/run/rsyslog
 RUN chown -R xrootd:xrootd /xcache/ /var/spool/rsyslog/workdir /var/run/rsyslog
@@ -82,6 +85,11 @@ COPY atlas-xcache/sbin/* /usr/local/sbin/
 COPY atlas-xcache/10-atlas-xcache-limits.conf /etc/security/limits.d
 COPY atlas-xcache/supervisord.d/10-atlas-xcache.conf /etc/supervisord.d/
 COPY atlas-xcache/image-config.d/10-atlas-xcache.sh /etc/osg/image-init.d/
+COPY atlas-xcache/rsyslog-atlas-xcache.conf /etc/rsyslog.d/atlas-xcache.conf
+
+RUN mkdir -p /var/log/xrootd/atlas-xcache && \
+    touch    /var/log/xrootd/atlas-xcache/xrootd.log && \
+    chown -R xrootd:xrootd /var/log/xrootd/atlas-xcache
 
 ##############
 # cms-xcache #
@@ -105,6 +113,11 @@ COPY cms-xcache/cron.d/* /etc/cron.d/
 RUN chmod 0644 /etc/cron.d/*
 COPY cms-xcache/image-config.d/* /etc/osg/image-init.d/
 COPY cms-xcache/xcache-consistency-check-wrapper.sh /usr/bin/xcache-consistency-check-wrapper.sh
+COPY cms-xcache/rsyslog-cms-xcache.conf /etc/rsyslog.d/cms-xcache.conf
+
+RUN mkdir -p /var/log/xrootd/cms-xcache && \
+    touch    /var/log/xrootd/cms-xcache/xrootd.log && \
+    chown -R xrootd:xrootd /var/log/xrootd/cms-xcache
 
 EXPOSE 1094
 
@@ -132,6 +145,15 @@ COPY stash-cache/image-config.d/* /etc/osg/image-init.d/
 COPY stash-cache/Authfile /run/stash-cache/Authfile
 # Same for scitokens.conf
 COPY stash-cache/scitokens.conf /run/stash-cache-auth/scitokens.conf
+
+COPY stash-cache/rsyslog-stash-cache.conf /etc/rsyslog.d/stash-cache.conf
+
+RUN mkdir -p /var/log/xrootd/stash-cache \
+             /var/log/xrootd/stash-cache-auth && \
+    touch    /var/log/xrootd/stash-cache/xrootd.log \
+             /var/log/xrootd/stash-cache-auth/xrootd.log && \
+    chown -R xrootd:xrootd /var/log/xrootd/stash-cache \
+                           /var/log/xrootd/stash-cache-auth
 
 EXPOSE 8000
 
@@ -164,6 +186,18 @@ COPY stash-origin/xrootd/* /etc/xrootd/config.d/
 # Add a placeholder scitokens.conf file, in case this origin isn't registered
 # and can't pull down a new one
 COPY stash-origin/scitokens.conf /run/stash-origin-auth/scitokens.conf
+
+COPY stash-origin/rsyslog-stash-origin.conf /etc/rsyslog.d/stash-origin.conf
+
+RUN mkdir -p /var/log/xrootd/stash-origin \
+             /var/log/xrootd/stash-origin-auth && \
+    touch    /var/log/xrootd/stash-origin/xrootd.log \
+             /var/log/xrootd/stash-origin/cmsd.log \
+             /var/log/xrootd/stash-origin-auth/xrootd.log \
+             /var/log/xrootd/stash-origin-auth/cmsd.log && \
+    chown -R xrootd:xrootd /var/log/xrootd/stash-origin \
+                           /var/log/xrootd/stash-origin-auth
+
 
 ######################
 # atlas-xcache-debug #

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN yum -y install /var/lib/xcache/*.rpm --enablerepo="osg-$BASE_YUM_REPO" || \
 
 RUN yum install -y \
         xcache \
+        rsyslog \
         gperftools-devel && \
     yum clean all --enablerepo=* && rm -rf /var/cache/yum/
 
@@ -49,8 +50,10 @@ ADD xcache/sbin/* /usr/local/sbin/
 ADD xcache/image-config.d/* /etc/osg/image-init.d/
 ADD xcache/xrootd/* /etc/xrootd/config.d/
 
-RUN mkdir -p "$XC_ROOTDIR"
-RUN chown -R xrootd:xrootd /xcache/
+RUN mkdir -p "$XC_ROOTDIR" /var/spool/rsyslog/workdir /var/run/rsyslog
+RUN chown -R xrootd:xrootd /xcache/ /var/spool/rsyslog/workdir /var/run/rsyslog
+
+COPY xcache/supervisord.d/* /etc/supervisord.d/
 
 RUN rm -f /etc/xrootd/macaroon-secret
 

--- a/atlas-xcache/rsyslog-atlas-xcache.conf
+++ b/atlas-xcache/rsyslog-atlas-xcache.conf
@@ -1,0 +1,9 @@
+input(
+  type="imfile"
+  File="/var/log/xrootd/atlas-xcache/xrootd.log"
+  Tag="atlas-xcache-xrootd"
+  Facility="local2"
+  Severity="info"
+  startmsg.regex="^[[:digit:]]{6} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2} [[:digit:]]+"
+  ruleset="XrootdLog"
+)

--- a/cms-xcache/rsyslog-cms-xcache.conf
+++ b/cms-xcache/rsyslog-cms-xcache.conf
@@ -1,0 +1,9 @@
+input(
+  type="imfile"
+  File="/var/log/xrootd/cms-xcache/xrootd.log"
+  Tag="cms-xcache-xrootd"
+  Facility="local2"
+  Severity="info"
+  startmsg.regex="^[[:digit:]]{6} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2} [[:digit:]]+"
+  ruleset="XrootdLog"
+)

--- a/stash-cache/rsyslog-stash-cache.conf
+++ b/stash-cache/rsyslog-stash-cache.conf
@@ -1,0 +1,19 @@
+input(
+  type="imfile"
+  File="/var/log/xrootd/stash-cache/xrootd.log"
+  Tag="stash-cache-xrootd"
+  Facility="local2"
+  Severity="info"
+  startmsg.regex="^[[:digit:]]{6} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2} [[:digit:]]+"
+  ruleset="XrootdLog"
+)
+
+input(
+  type="imfile"
+  File="/var/log/xrootd/stash-cache-auth/xrootd.log"
+  Tag="stash-cache-auth-xrootd"
+  Facility="local2"
+  Severity="info"
+  startmsg.regex="^[[:digit:]]{6} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2} [[:digit:]]+"
+  ruleset="XrootdLog"
+)

--- a/stash-origin/rsyslog-stash-origin.conf
+++ b/stash-origin/rsyslog-stash-origin.conf
@@ -1,0 +1,39 @@
+input(
+  type="imfile"
+  File="/var/log/xrootd/stash-origin/xrootd.log"
+  Tag="stash-origin-xrootd"
+  Facility="local2"
+  Severity="info"
+  startmsg.regex="^[[:digit:]]{6} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2} [[:digit:]]+"
+  ruleset="XrootdLog"
+)
+
+input(
+  type="imfile"
+  File="/var/log/xrootd/stash-origin/cmsd.log"
+  Tag="stash-origin-cmsd"
+  Facility="local2"
+  Severity="info"
+  startmsg.regex="^[[:digit:]]{6} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2} [[:digit:]]+"
+  ruleset="XrootdLog"
+)
+
+input(
+  type="imfile"
+  File="/var/log/xrootd/stash-origin-auth/xrootd.log"
+  Tag="stash-origin-auth-xrootd"
+  Facility="local2"
+  Severity="info"
+  startmsg.regex="^[[:digit:]]{6} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2} [[:digit:]]+"
+  ruleset="XrootdLog"
+)
+
+input(
+  type="imfile"
+  File="/var/log/xrootd/stash-origin-auth/cmsd.log"
+  Tag="stash-origin-auth-cmsd"
+  Facility="local2"
+  Severity="info"
+  startmsg.regex="^[[:digit:]]{6} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2} [[:digit:]]+"
+  ruleset="XrootdLog"
+)

--- a/xcache/image-config.d/10-no-rsyslog.sh
+++ b/xcache/image-config.d/10-no-rsyslog.sh
@@ -1,0 +1,3 @@
+if [[ ${NO_RSYSLOG:-0} == 1 ]]; then
+    rm -f "/etc/supervisord.d/00-rsyslogd.conf"
+fi

--- a/xcache/rsyslog.conf
+++ b/xcache/rsyslog.conf
@@ -1,0 +1,100 @@
+# Listen to the traditional syslog Unix socket.
+module(
+load="imuxsock"
+SysSock.Unlink="off"
+SysSock.UsePIDFromSystem="on"
+)
+
+# Include ability to poll existing files
+module(
+load="imfile"
+PollingInterval="1"
+)
+
+# Where to place auxiliary files
+global(workDirectory="/var/spool/rsyslog/workdir")
+
+template(name="Xrootd_SyslogProtocol23Format" type="list")
+{
+    constant(value="<")
+    property(name="pri")
+    constant(value=">1 ")
+    property(name="$.year")
+    constant(value="-")
+    property(name="$.month")
+    constant(value="-")
+    property(name="$.day")
+    constant(value="T")
+    property(name="$.hour")
+    constant(value=":")
+    property(name="$.min")
+    constant(value=":")
+    property(name="$.sec")
+    constant(value="Z ")
+    constant(value=" ")
+    property(name="hostname")
+    constant(value=" ")
+    property(name="app-name")
+    constant(value=" ")
+    property(name="$.pid")
+    constant(value=" - - ")
+    property(name="msg"
+             regex.type="ERE"
+             regex.expression="(^[[:digit:]]{6} [[:digit:]]{2}\\:[[:digit:]]{2}\\:[[:digit:]]{2} [[:digit:]]+ (.*))"
+             regex.submatch="2"
+            )
+    constant(value="\n")
+}
+
+ruleset(name="XrootdTimestamp") {
+  # substring function not available until 8.32; RHEL7 is 8.24
+  #set $.year = "20" & substring($msg, 0, 2);
+  set $.year = "20" & re_extract($msg, "(^[[:digit:]]{2})", 0, 0, "");
+  #set $.month = substring($msg, 2, 2);
+  set $.month = re_extract($msg, "^[[:digit:]]{2}([[:digit:]]{2})", 0, 1, "");
+  #set $.day = substring($msg, 4, 2);
+  set $.day = re_extract($msg, "^[[:digit:]]{4}([[:digit:]]{2})", 0, 1, "");
+
+  #set $.hour = substring($msg, 7, 2);
+  set $.hour = re_extract($msg, "^.{7}([[:digit:]]{2})", 0, 1, "");
+  #set $.min = substring($msg, 10, 2);
+  set $.min = re_extract($msg, "^.{10}([[:digit:]]{2})", 0, 1, "");
+  #set $.sec = substring($msg, 13, 2);
+  set $.sec = re_extract($msg, "^.{13}([[:digit:]]{2})", 0, 1, "");
+
+  set $.pid = field($msg, 32, 3);
+}
+
+ruleset(name="XrootdLog") {
+
+  call XrootdTimestamp
+
+  action(type="omfile" file="/dev/stdout"
+        template="Xrootd_SyslogProtocol23Format"
+        )
+}
+
+module(load="builtin:omfile" Template="Xrootd_SyslogProtocol23Format")
+
+input(
+  type="imfile"
+  File="/var/log/xrootd/stash-cache/xrootd.log"
+  Tag="stash-cache"
+  Facility="local2"
+  Severity="info"
+  startmsg.regex="^[[:digit:]]{6} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2} [[:digit:]]+"
+  ruleset="XrootdLog"
+)
+
+input(
+  type="imfile"
+  File="/var/log/xrootd/stash-cache-auth/xrootd.log"
+  Tag="stash-cache-auth"
+  Facility="local2"
+  Severity="info"
+  startmsg.regex="^[[:digit:]]{6} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2} [[:digit:]]+"
+  ruleset="XrootdLog"
+)
+
+# Log all messages to the syslog daemon's stdout.
+*.* /dev/stdout

--- a/xcache/rsyslog.conf
+++ b/xcache/rsyslog.conf
@@ -76,25 +76,8 @@ ruleset(name="XrootdLog") {
 
 module(load="builtin:omfile" Template="Xrootd_SyslogProtocol23Format")
 
-input(
-  type="imfile"
-  File="/var/log/xrootd/stash-cache/xrootd.log"
-  Tag="stash-cache"
-  Facility="local2"
-  Severity="info"
-  startmsg.regex="^[[:digit:]]{6} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2} [[:digit:]]+"
-  ruleset="XrootdLog"
-)
-
-input(
-  type="imfile"
-  File="/var/log/xrootd/stash-cache-auth/xrootd.log"
-  Tag="stash-cache-auth"
-  Facility="local2"
-  Severity="info"
-  startmsg.regex="^[[:digit:]]{6} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2} [[:digit:]]+"
-  ruleset="XrootdLog"
-)
+$IncludeConfig /etc/rsyslog.d/*.conf
 
 # Log all messages to the syslog daemon's stdout.
 *.* /dev/stdout
+

--- a/xcache/supervisord.d/00-rsyslogd.conf
+++ b/xcache/supervisord.d/00-rsyslogd.conf
@@ -1,0 +1,8 @@
+[program:rsyslogd]
+command=/usr/sbin/rsyslogd -f /etc/rsyslog.conf -n -i /var/run/rsyslog/ryslog.pid
+#user=xrootd
+autorestart=true
+stdout_logfile=/proc/self/fd/1
+stderr_logfile=/proc/self/fd/2
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
This forwards the contents of the xrootd logs to the stdout of the container, improving the ability to debug the stack.