### PR TITLE
SOFTWARE-5924: Remove el7 builds from Github Workflows

### DIFF
--- a/.github/workflows/hotfix-image-builds.yml
+++ b/.github/workflows/hotfix-image-builds.yml
@@ -1,6 +1,6 @@
 # TODO: detect the appropriate OSG repos and OS for build and installation
 # Currently we assume that upstream's version corresponds to what's in
-# osg-upcoming-el9-build and osg-upcoming-testing
+# osg-upcoming-el8-build and osg-upcoming-testing
 
 name: Build XCache images based off of XRootD hotfix tags
 on:
@@ -51,7 +51,7 @@ jobs:
               -v $(pwd)/xrootd/:/xrootd \
               -v $(pwd)/_build_dir:/u/_build_dir \
               --privileged \
-              opensciencegrid/osg-build:el9 \
+              opensciencegrid/osg-build:el8 \
               osg-build --verbose mock --mock-config-from-koji=osg-3.5-upcoming-el7-build _build_dir
       - name: Move hotfix RPMs
         if: steps.hotfix-tags.outputs.tag != 0

--- a/.github/workflows/hotfix-image-builds.yml
+++ b/.github/workflows/hotfix-image-builds.yml
@@ -1,6 +1,6 @@
 # TODO: detect the appropriate OSG repos and OS for build and installation
 # Currently we assume that upstream's version corresponds to what's in
-# osg-upcoming-el7-build and osg-upcoming-testing
+# osg-upcoming-el9-build and osg-upcoming-testing
 
 name: Build XCache images based off of XRootD hotfix tags
 on:
@@ -51,7 +51,7 @@ jobs:
               -v $(pwd)/xrootd/:/xrootd \
               -v $(pwd)/_build_dir:/u/_build_dir \
               --privileged \
-              opensciencegrid/osg-build:el7 \
+              opensciencegrid/osg-build:el9 \
               osg-build --verbose mock --mock-config-from-koji=osg-3.5-upcoming-el7-build _build_dir
       - name: Move hotfix RPMs
         if: steps.hotfix-tags.outputs.tag != 0

--- a/.github/workflows/release-series-builds.yml
+++ b/.github/workflows/release-series-builds.yml
@@ -23,7 +23,7 @@ jobs:
         repo: ['development', 'testing', 'release']
         osg_series:
           - name: '3.6'
-            os: 'el9'
+            os: 'el8'
           - name: '23'
             os: 'el9'
     steps:
@@ -65,7 +65,7 @@ jobs:
         repo: ['development', 'testing', 'release']
         osg_series:
           - name: '3.6'
-            os: 'el9'
+            os: 'el8'
           - name: '23'
             os: 'el9'
     runs-on: ubuntu-latest
@@ -110,7 +110,7 @@ jobs:
         repo: ['development', 'testing', 'release']
         osg_series:
           - name: '3.6'
-            os: 'el9'
+            os: 'el8'
           - name: '23'
             os: 'el9'
     steps:
@@ -180,7 +180,7 @@ jobs:
         repo: ['development', 'testing', 'release']
         osg_series:
           - name: '3.6'
-            os: 'el9'
+            os: 'el8'
           - name: '23'
             os: 'el9'
     needs: [make-date-tag, test-stash-cache]

--- a/.github/workflows/release-series-builds.yml
+++ b/.github/workflows/release-series-builds.yml
@@ -23,7 +23,7 @@ jobs:
         repo: ['development', 'testing', 'release']
         osg_series:
           - name: '3.6'
-            os: 'el7'
+            os: 'el9'
           - name: '23'
             os: 'el9'
     steps:
@@ -65,7 +65,7 @@ jobs:
         repo: ['development', 'testing', 'release']
         osg_series:
           - name: '3.6'
-            os: 'el7'
+            os: 'el9'
           - name: '23'
             os: 'el9'
     runs-on: ubuntu-latest
@@ -110,7 +110,7 @@ jobs:
         repo: ['development', 'testing', 'release']
         osg_series:
           - name: '3.6'
-            os: 'el7'
+            os: 'el9'
           - name: '23'
             os: 'el9'
     steps:
@@ -180,7 +180,7 @@ jobs:
         repo: ['development', 'testing', 'release']
         osg_series:
           - name: '3.6'
-            os: 'el7'
+            os: 'el9'
           - name: '23'
             os: 'el9'
     needs: [make-date-tag, test-stash-cache]


### PR DESCRIPTION
Build 3.6 images in el9 instead of el7