### PR TITLE
Don't have supervisord run authfile-update

### DIFF
--- a/stash-cache/supervisord.d/10-stash-cache.conf
+++ b/stash-cache/supervisord.d/10-stash-cache.conf
@@ -1,8 +1,3 @@
-[program:stash-cache-authfile-update]
-command=/usr/libexec/xcache/authfile-update --cache
-user=xrootd
-priority=998
-
 [program:stash-cache]
 command=xrootd -c /etc/xrootd/xrootd-stash-cache.cfg -k fifo -n stash-cache -k %(ENV_XC_NUM_LOGROTATE)s -s /var/run/xrootd/xrootd-stash-cache.pid -l /var/log/xrootd/xrootd.log
 user=xrootd


### PR DESCRIPTION
We run authfile-update at image init time; also putting it into supervisor just causes errors because it's a script, not a service, and it exits.

```
2024-11-05 21:10:35,906 INFO spawned: 'stash-cache-authfile-update' with pid 543
2024-11-05 21:10:36,120 WARN exited: stash-cache-authfile-update (exit status 0; not expected)
2024-11-05 21:10:38,126 INFO spawned: 'stash-cache-authfile-update' with pid 544
2024-11-05 21:10:38,327 WARN exited: stash-cache-authfile-update (exit status 0; not expected)
2024-11-05 21:10:41,332 INFO spawned: 'stash-cache-authfile-update' with pid 547
2024-11-05 21:10:41,534 WARN exited: stash-cache-authfile-update (exit status 0; not expected)
2024-11-05 21:10:42,536 INFO gave up: stash-cache-authfile-update entered FATAL state, too many start retries too quickly
```