### PR TITLE
SOFTWARE-6027: OSG 24 (take 2)

### DIFF
--- a/.github/workflows/release-series-builds.yml
+++ b/.github/workflows/release-series-builds.yml
@@ -66,6 +66,8 @@ jobs:
         osg_series:
           - name: '23'
             os: 'el9'
+          - name: '24'
+            os: 'el9'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -108,6 +110,8 @@ jobs:
         repo: ['development', 'testing', 'release']
         osg_series:
           - name: '23'
+            os: 'el9'
+          - name: '24'
             os: 'el9'
     steps:
       - uses: actions/checkout@v3
@@ -177,6 +181,10 @@ jobs:
         osg_series:
           - name: '23'
             os: 'el9'
+            organization: 'opensciencegrid'
+          - name: '24'
+            os: 'el9'
+            organization: 'osg-htc'
     needs: [make-date-tag, test-stash-cache]
     runs-on: ubuntu-latest
     steps:
@@ -194,11 +202,16 @@ jobs:
           REPO: ${{ matrix.repo }}
           SERIES: ${{ matrix.osg_series.name }}
           IMAGE: ${{ matrix.image }}
+          ORGANIZATION: ${{ matrix.osg_series.organization }}
           TIMESTAMP: ${{ needs.make-date-tag.outputs.dtag }}
         run: |
-          docker_repo=opensciencegrid/$IMAGE
+          docker_repo=$ORGANIZATION/$IMAGE
           tag_list=()
           for registry in hub.opensciencegrid.org docker.io; do
+            # osg-htc org doesn't exist in docker.io
+            if [[ "$registry" == "docker.io" && "$ORGANIZATION" == "osg-htc" ]]; then
+              continue
+            fi
             for image_tag in "$SERIES-$REPO" "$SERIES-$REPO-$TIMESTAMP"; do
               tag_list+=("$registry/$docker_repo":"$image_tag")
             done

--- a/.github/workflows/release-series-builds.yml
+++ b/.github/workflows/release-series-builds.yml
@@ -68,6 +68,13 @@ jobs:
             os: 'el9'
           - name: '24'
             os: 'el9'
+        exclude:
+          - osg_series:
+              name: 24
+            image: stash-cache
+          - osg_series:
+              name: 24
+            image: stash-origin
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -109,9 +116,8 @@ jobs:
       matrix:
         repo: ['development', 'testing', 'release']
         osg_series:
+          # TODO build new test suite for osg 24 pelican origin/cache tooling
           - name: '23'
-            os: 'el9'
-          - name: '24'
             os: 'el9'
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release-series-builds.yml
+++ b/.github/workflows/release-series-builds.yml
@@ -191,6 +191,13 @@ jobs:
           - name: '24'
             os: 'el9'
             organization: 'osg-htc'
+        exclude:
+          - osg_series:
+              name: 24
+            image: stash-cache
+          - osg_series:
+              name: 24
+            image: stash-origin
     needs: [make-date-tag, test-stash-cache]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
- Update `xcache-image-build` and `push-images` build matrices to include osg 24
- Exclude stash-cache/origin builds from OSG 24 build matrices since those RPMs are dropped from OSG 24